### PR TITLE
New GPU kernel for DDsmu_mocks initial PR.

### DIFF
--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -21,7 +21,7 @@ def DDsmu_mocks(autocorr, nthreads, binfile, mumax, nmubins,
                 xbin_refine_factor=2, ybin_refine_factor=2,
                 zbin_refine_factor=1, max_cells_per_dim=100,
                 copy_particles=True, enable_min_sep_opt=True,
-                c_api_timer=False, isa='fastest',
+                c_api_timer=False, isa='fastest', gpu=False,
                 weight_type=None, bin_type='custom', los_type='midpoint',
                 pair_weights=None, sep_pair_weights=None, attrs_pair_weights=None, attrs_selection=None):
     """
@@ -173,6 +173,9 @@ def DDsmu_mocks(autocorr, nthreads, binfile, mumax, nmubins,
        benchmarking, then the string supplied here gets translated into an
        ``enum`` for the instruction set defined in ``utils/defs.h``.
 
+    gpu : bool (default False)
+        If ``True``, use GPU (nvidia) instead of CPU.
+
     weight_type : string, optional (default None)
         The type of weighting to apply. One of ["pair_product", "inverse_bitwise", None].
 
@@ -265,6 +268,11 @@ def DDsmu_mocks(autocorr, nthreads, binfile, mumax, nmubins,
         Y2 = np.empty(1)
         Z2 = np.empty(1)
 
+    if gpu and nthreads > 1:
+        import warnings
+        warnings.warn('cannot use more than 1 thread with GPU')
+        nthreads = 1
+
     weights1, weights2 = process_weights(weights1, weights2, X1, X2, weight_type, autocorr)
 
     # Ensure all input arrays are native endian
@@ -308,6 +316,7 @@ def DDsmu_mocks(autocorr, nthreads, binfile, mumax, nmubins,
                                   enable_min_sep_opt=enable_min_sep_opt,
                                   c_api_timer=c_api_timer,
                                   isa=integer_isa,
+                                  gpu=int(gpu),
                                   bin_type=integer_bin_type,
                                   los_type=integer_los_type,
                                   **kwargs)

--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -268,11 +268,6 @@ def DDsmu_mocks(autocorr, nthreads, binfile, mumax, nmubins,
         Y2 = np.empty(1)
         Z2 = np.empty(1)
 
-    if gpu and nthreads > 1:
-        import warnings
-        warnings.warn('cannot use more than 1 thread with GPU')
-        nthreads = 1
-
     weights1, weights2 = process_weights(weights1, weights2, X1, X2, weight_type, autocorr)
 
     # Ensure all input arrays are native endian

--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,16 @@ CFLAGS ?=
 #### Add any compiler specific link flags you want
 CLINK ?=
 
-CUFLAGS := -ccbin gcc   -m64  -gencode arch=compute_60,code=sm_60  -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_86,code=compute_86 -Xcompiler -Ofast -I../../io -I../../utils  -c
+CUFLAGS := -ccbin gcc -m64 -gencode arch=compute_60,code=sm_60  -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_86,code=compute_86 -Xcompiler -Ofast --compiler-options '-fPIC' -I../../io -I../../utils -c
+
+NVCC_RESULT := $(shell which nvcc 2> NULL)
+NVCC_TEST := $(notdir $(NVCC_RESULT))
+ifeq ($(NVCC_TEST),nvcc)
+#Add GPU module to LIBSRC
+CFLAGS += -DGPU
+CLINK += -L$(CUDA_HOME)/lib64 -lcudart
+CUDA_INCLUDE := $(CUDA_HOME)/include
+endif
 
 ## Set the python command (supply the full path to python you want to
 ## use, if different from directly calling `python` on the shell,

--- a/common.mk
+++ b/common.mk
@@ -16,6 +16,8 @@ CFLAGS ?=
 #### Add any compiler specific link flags you want
 CLINK ?=
 
+CUFLAGS := -ccbin gcc   -m64  -gencode arch=compute_60,code=sm_60  -gencode arch=compute_61,code=sm_61 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_86,code=compute_86 -Xcompiler -Ofast -I../../io -I../../utils  -c
+
 ## Set the python command (supply the full path to python you want to
 ## use, if different from directly calling `python` on the shell,
 ## as can be the case if python is set via an alias)

--- a/mocks/DDsmu_mocks/DDsmu_mocks.c
+++ b/mocks/DDsmu_mocks/DDsmu_mocks.c
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
 
     weight_method_t weight_method = NONE;
     int num_weights = 0;
+    bool use_gpu = false;
 
     /*---Data-variables--------------------*/
     int64_t ND1,ND2 ;
@@ -99,8 +100,14 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    for (int i=1; i<argc; i++) {
+        if (!strcmp(argv[i],"-gpu")) use_gpu = true;
+    }
+    if (use_gpu) fprintf(stderr, "USE GPU\n");
+
     /* Validate optional arguments */
     int noptargs_given = argc - (nargs + 1);
+    if (use_gpu) noptargs_given--;
     if(noptargs_given != 0 && noptargs_given != 3 && noptargs_given != 5){
         Printhelp();
         fprintf(stderr,"\nFound: %d optional arguments; must be 0 (no weights), 3 (for one set of weights) or 5 (for two sets)\n ", noptargs_given);
@@ -220,6 +227,7 @@ int main(int argc, char *argv[])
     /*---Count-pairs--------------------------------------*/
     results_countpairs_mocks_s_mu results;
     struct config_options options = get_config_options();
+    set_gpu_mode(&options, (uint8_t)use_gpu);
 
     /* Pack weights into extra options */
     struct extra_options extra = get_extra_options(weight_method);
@@ -261,7 +269,7 @@ int main(int argc, char *argv[])
         const double log_supp = LOG10(results.supp[i]);
         for(int j=0;j<nmubin;j++) {
             const int index = i*(nmubin+1) + j;
-            fprintf(stdout,"%10"PRIu64" %20.8lf %20.8lf  %20.8lf %20.8lf \n",results.npairs[index],results.savg[index],log_supp,(j+1)*dmu-mu_max,results.weightavg[index]);
+            fprintf(stdout,"%10"PRIu64" %20.8lf %20.8lf  %20.8lf %20.8lf \n",results.npairs[index],results.savg[index],log_supp,(j+1)*dmu-mu_max, results.weightavg[index]);
         }
     }
 
@@ -325,6 +333,12 @@ void Printhelp(void)
     fprintf(stderr,"Use OMP = True\n");
 #else
     fprintf(stderr,"Use OMP = False\n");
+#endif
+
+#ifdef GPU
+    fprintf(stderr,"Use GPU = True\n");
+#else
+    fprintf(stderr,"Use GPU = False\n");
 #endif
 
     fprintf(stderr,"=========================================================================\n") ;

--- a/mocks/DDsmu_mocks/Makefile
+++ b/mocks/DDsmu_mocks/Makefile
@@ -20,8 +20,6 @@ LIBSRC  := countpairs_s_mu_mocks.c countpairs_s_mu_mocks_impl_double.c countpair
 ifeq ($(NVCC_TEST),nvcc)
 #Add GPU module to LIBSRC
 LIBSRC += countpairs_s_mu_mocks_gpu.o
-CFLAGS += -DGPU
-CLINK += -L$(CUDA_HOME)/lib64 -lcudart
 endif
 LIBRARY_HEADERS := $(LIBNAME).h
 
@@ -41,8 +39,7 @@ INCL     := countpairs_s_mu_mocks_kernels_float.c countpairs_s_mu_mocks_kernels_
             $(UTILS_DIR)/weight_functions_double.h $(UTILS_DIR)/weight_functions_float.h $(UTILS_DIR)/weight_functions.h.src \
 	        $(UTILS_DIR)/weight_defs_double.h $(UTILS_DIR)/weight_defs_float.h $(UTILS_DIR)/weight_defs.h.src
 ifeq ($(NVCC_TEST),nvcc)
-#Add CUDA include dir
-INCL += countpairs_s_mu_mocks_gpu.h $(CUDA_HOME)/include
+INCL += countpairs_s_mu_mocks_gpu.h $(CUDA_INCLUDE)
 endif
 
 TARGETOBJS:=$(TARGETSRC:.c=.o)

--- a/mocks/DDsmu_mocks/Makefile
+++ b/mocks/DDsmu_mocks/Makefile
@@ -5,6 +5,9 @@ INSTALL_BIN_DIR := $(ROOT_DIR)/bin
 UTILS_DIR := $(ROOT_DIR)/utils
 IO_DIR := $(ROOT_DIR)/io
 
+NVCC_RESULT := $(shell which nvcc 2> NULL)
+NVCC_TEST := $(notdir $(NVCC_RESULT))
+
 GSL_REQUIRED := false
 include $(ROOT_DIR)/mocks.options $(ROOT_DIR)/common.mk
 
@@ -14,6 +17,12 @@ LIBSRC  := countpairs_s_mu_mocks.c countpairs_s_mu_mocks_impl_double.c countpair
            $(UTILS_DIR)/gridlink_mocks_impl_float.c $(UTILS_DIR)/gridlink_mocks_impl_double.c \
            $(UTILS_DIR)/gridlink_utils_float.c $(UTILS_DIR)/gridlink_utils_double.c \
            $(UTILS_DIR)/utils.c $(UTILS_DIR)/progressbar.c $(UTILS_DIR)/cpu_features.c $(UTILS_DIR)/avx512_calls.c
+ifeq ($(NVCC_TEST),nvcc)
+#Add GPU module to LIBSRC
+LIBSRC += countpairs_s_mu_mocks_gpu.o
+CFLAGS += -DGPU
+CLINK += -L$(CUDA_HOME)/lib64 -lcudart
+endif
 LIBRARY_HEADERS := $(LIBNAME).h
 
 TARGET   := DDsmu_mocks
@@ -31,6 +40,10 @@ INCL     := countpairs_s_mu_mocks_kernels_float.c countpairs_s_mu_mocks_kernels_
 	        $(UTILS_DIR)/utils.h $(UTILS_DIR)/function_precision.h $(UTILS_DIR)/avx512_calls.h $(UTILS_DIR)/avx_calls.h $(UTILS_DIR)/defs.h \
             $(UTILS_DIR)/weight_functions_double.h $(UTILS_DIR)/weight_functions_float.h $(UTILS_DIR)/weight_functions.h.src \
 	        $(UTILS_DIR)/weight_defs_double.h $(UTILS_DIR)/weight_defs_float.h $(UTILS_DIR)/weight_defs.h.src
+ifeq ($(NVCC_TEST),nvcc)
+#Add CUDA include dir
+INCL += countpairs_s_mu_mocks_gpu.h $(CUDA_HOME)/include
+endif
 
 TARGETOBJS:=$(TARGETSRC:.c=.o)
 LIBOBJS:=$(LIBSRC:.c=.o)

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.cu
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.cu
@@ -18,6 +18,7 @@ extern "C" {
 #include "cellarray_mocks_float.h"
 
 #include "countpairs_s_mu_mocks_gpu.h"
+#include <cuda_runtime.h>
 }
 
 __global__ void countpairs_s_mu_mocks_kernel_double(double *x0, double *y0, double *z0,

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.cu
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.cu
@@ -1,0 +1,1108 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <math.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+//#include <iostream>
+extern "C" {
+#include "defs.h"
+//#include "function_precision.h"
+//#include "utils.h"
+//#include "gridlink_utils_double.h"
+
+//#include "weight_functions_double.h"
+
+#include "cellarray_mocks_double.h"
+#include "cellarray_mocks_float.h"
+
+#include "countpairs_s_mu_mocks_gpu.h"
+}
+
+__global__ void countpairs_s_mu_mocks_kernel_double(double *x0, double *y0, double *z0,
+               double *x1, double *y1, double *z1, int N,
+               int *np0, int *np1, 
+               int *same_cell, int64_t *icell0, int64_t *icell1, 
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               double *min_xdiff, double *min_ydiff, 
+               double *savg, int *npairs, const double *supp_sqr,
+               const double sqr_smax, const double sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const double sqr_mumax, const double inv_dmu, const double mumin_invstep,
+               double inv_sstep, double smin_invstep,
+               int need_savg, int autocorr, int los_type, int bin_type) {
+    //thread index tidx 
+    int tidx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tidx >= N) return;
+
+    int icellpair = cellpair_lut[blockIdx.x]; //use block index to find cellpair index
+    int cell_tidx = cellthread_lut[blockIdx.x] + threadIdx.x; //index within this cellpair from 0 to np0*np1-1
+
+    //icell0, icell1 will translate icellpair to a cell within each lattice
+    //start_idx0, start_idx1 then translate to i, j in x0,y0,z0 and x1,y1,z1
+    int64_t cellindex0 = icell0[icellpair];
+    int64_t cellindex1 = icell1[icellpair];
+    //nthreads = np0 * np1 for each cell pair icell
+    int this_np0 = np0[cellindex0];
+    int this_np1 = np1[cellindex1];
+    if (cell_tidx >= this_np0*this_np1) return;
+
+    //start_idx0, start_idx1 give index for first element of x0, y0, z0 and x1, y1, z1 in cell icell.
+    //% and / to get i, j
+    int i = start_idx0[cellindex0] + cell_tidx / this_np1;
+    int j = start_idx1[cellindex1] + cell_tidx % this_np1;
+
+    //get positions for each particle
+    double xpos = x0[i];
+    double ypos = y0[i];
+    double zpos = z0[i];
+
+    double x1pos = x1[j];
+    double y1pos = y1[j];
+    double z1pos = z1[j];
+
+    if (same_cell[icellpair] && z1pos <= zpos) { 
+        //return if same particle or in same cell with z1 < z0
+        //this way we do not double count pairs
+        return;
+    }
+
+    const double max_dz = sqrt(sqr_smax - min_xdiff[icellpair]*min_xdiff[icellpair] - min_ydiff[icellpair]*min_ydiff[icellpair]);
+    const double this_dz = z1pos-zpos;
+    if (abs(this_dz) >= max_dz) {
+        //particle too far away in z
+        return;
+    }
+
+    const double this_dx = x1pos-xpos;
+    const double this_dy = y1pos-ypos;
+    if ((this_dx*this_dx + this_dy*this_dy + this_dz*this_dz) >= sqr_smax) {
+        //particle too far away in separation
+        return;
+    } 
+
+    //hat1 calcs are done if need_weightavg || ((autocorr == 1) && (los_type == FIRSTPOINT_LOS)
+    //need_weightavg is FALSE by definition in this kernel so remove that part of conditional 
+    double xhat1=NULL, yhat1=NULL, zhat1=NULL;
+    if (((autocorr == 1) && (los_type == FIRSTPOINT_LOS))) {
+        const double norm1 = sqrt(x1pos*x1pos + y1pos*y1pos + z1pos*z1pos);
+        xhat1 = x1pos/norm1;
+        yhat1 = y1pos/norm1;
+        zhat1 = z1pos/norm1;
+    }
+
+    //hat1 calcs are done if need_weightavg || los_type == FIRSTPOINT_LOS 
+    //need_weightavg is FALSE by definition in this kernel so remove that part of conditional 
+    double xhat0=NULL, yhat0=NULL, zhat0=NULL;
+    if (los_type == FIRSTPOINT_LOS) {
+        const double norm0 = sqrt(xpos*xpos + ypos*ypos + zpos*zpos);
+        xhat0 = xpos/norm0;
+        yhat0 = ypos/norm0;
+        zhat0 = zpos/norm0;
+    }
+
+    const double parx = xpos + x1pos;
+    const double pary = ypos + y1pos; 
+    const double parz = zpos + z1pos; 
+
+    const double perpx = x1pos - xpos;
+    const double perpy = y1pos - ypos;
+    const double perpz = z1pos - zpos;
+
+    //return if greater than max dz
+    if (perpz > max_dz) {
+        return;
+    }
+
+    const double sqr_s = perpx*perpx + perpy*perpy + perpz*perpz;
+    if(sqr_s >= sqr_smax || sqr_s < sqr_smin) {
+        return;
+    } 
+
+    double s = 0;
+    int mubin = nmu_bins, mubin2 = nmu_bins;
+    if (sqr_s <= 0.) {
+        mubin2 = mubin = (int) mumin_invstep;
+    } 
+    else if (los_type == MIDPOINT_LOS) {
+        const double s_dot_l = parx*perpx + pary*perpy + parz*perpz;
+        const double sqr_l = parx*parx + pary*pary + parz*parz;
+        const double sqr_mu = s_dot_l * s_dot_l / (sqr_l * sqr_s);
+        if (sqr_mu >= sqr_mumax) {
+            return;
+        } 
+        const double mu = s_dot_l >= 0 ? sqrt(sqr_mu) : -sqrt(sqr_mu);
+        mubin = (int) (mu * inv_dmu + mumin_invstep);
+        if (autocorr == 1) mubin2 = (int) (- mu * inv_dmu + mumin_invstep);
+        if(need_savg || bin_type == BIN_LIN) s = sqrt(sqr_s);
+    }
+    else {
+        const double s_dot_l = xhat0*perpx + yhat0*perpy + zhat0*perpz;
+        const double sqr_mu = s_dot_l * s_dot_l / sqr_s;
+        if (autocorr == 1) {
+            const double s_dot_l2 = xhat1*perpx + yhat1*perpy + zhat1*perpz;
+	    const double sqr_mu2 = s_dot_l2 * s_dot_l2 / sqr_s;
+	    const int skip_mu = (sqr_mu >= sqr_mumax);
+	    const int skip_mu2 = (sqr_mu2 >= sqr_mumax);
+	    if (skip_mu && skip_mu2) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    if (skip_mu == 0) mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	    if (skip_mu2 == 0) mubin2 = (int) (- s_dot_l2 / s * inv_dmu + mumin_invstep);
+	}
+	else {
+	    if (sqr_mu >= sqr_mumax) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	}
+    }
+
+    double sw = s;
+    int kbin = 0;
+    if (bin_type == BIN_LIN) {
+	kbin = (int) (s*inv_sstep + smin_invstep);
+    }
+    else {
+	for(kbin=nsbin-1;kbin>=1;kbin--) {
+	    if(sqr_s >= supp_sqr[kbin-1]) {
+		break;
+	    }
+	}//finding kbin
+    }
+    kbin *= nmu_bins+1;
+    {
+	const int ibin = kbin + mubin;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+    }
+    if (autocorr == 1) {
+	const int ibin = kbin + mubin2;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+    }
+}
+
+__global__ void countpairs_s_mu_mocks_kernel_float(float *x0, float *y0, float *z0,
+               float *x1, float *y1, float *z1, int N,
+               int *np0, int *np1, 
+               int *same_cell, int64_t *icell0, int64_t *icell1, 
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               float *min_xdiff, float *min_ydiff, 
+               float *savg, int *npairs, const float *supp_sqr,
+               const float sqr_smax, const float sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const float sqr_mumax, const float inv_dmu, const float mumin_invstep,
+               float inv_sstep, float smin_invstep,
+               int need_savg, int autocorr, int los_type, int bin_type) {
+    //thread index tidx 
+    int tidx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tidx >= N) return;
+
+    int icellpair = cellpair_lut[blockIdx.x]; //use block index to find cellpair index
+    int cell_tidx = cellthread_lut[blockIdx.x] + threadIdx.x; //index within this cellpair from 0 to np0*np1-1
+
+    //icell0, icell1 will translate icellpair to a cell within each lattice
+    //start_idx0, start_idx1 then translate to i, j in x0,y0,z0 and x1,y1,z1
+    int64_t cellindex0 = icell0[icellpair];
+    int64_t cellindex1 = icell1[icellpair];
+    //nthreads = np0 * np1 for each cell pair icell
+    int this_np0 = np0[cellindex0];
+    int this_np1 = np1[cellindex1];
+    if (cell_tidx >= this_np0*this_np1) return;
+
+    //start_idx0, start_idx1 give index for first element of x0, y0, z0 and x1, y1, z1 in cell icell.
+    //% and / to get i, j
+    int i = start_idx0[cellindex0] + cell_tidx / this_np1;
+    int j = start_idx1[cellindex1] + cell_tidx % this_np1;
+
+    //get positions for each particle
+    float xpos = x0[i];
+    float ypos = y0[i];
+    float zpos = z0[i];
+
+    float x1pos = x1[j];
+    float y1pos = y1[j];
+    float z1pos = z1[j];
+
+    if (same_cell[icellpair] && z1pos <= zpos) { 
+        //return if same particle or in same cell with z1 < z0
+        //this way we do not float count pairs
+        if (z1pos < zpos) return;
+        if (z1pos == zpos && j <= i) return;
+        //return;
+    }
+
+    const float max_dz = sqrt(sqr_smax - min_xdiff[icellpair]*min_xdiff[icellpair] - min_ydiff[icellpair]*min_ydiff[icellpair]);
+    const float this_dz = z1pos-zpos;
+    if (abs(this_dz) >= max_dz) {
+        //particle too far away in z
+        return;
+    }
+
+    const float this_dx = x1pos-xpos;
+    const float this_dy = y1pos-ypos;
+    if ((this_dx*this_dx + this_dy*this_dy + this_dz*this_dz) >= sqr_smax) {
+        //particle too far away in separation
+        return;
+    } 
+
+    //hat1 calcs are done if need_weightavg || ((autocorr == 1) && (los_type == FIRSTPOINT_LOS)
+    //need_weightavg is FALSE by definition in this kernel so remove that part of conditional 
+    float xhat1=NULL, yhat1=NULL, zhat1=NULL;
+    if (((autocorr == 1) && (los_type == FIRSTPOINT_LOS))) {
+        const float norm1 = sqrt(x1pos*x1pos + y1pos*y1pos + z1pos*z1pos);
+        xhat1 = x1pos/norm1;
+        yhat1 = y1pos/norm1;
+        zhat1 = z1pos/norm1;
+    }
+
+    //hat1 calcs are done if need_weightavg || los_type == FIRSTPOINT_LOS 
+    //need_weightavg is FALSE by definition in this kernel so remove that part of conditional 
+    float xhat0=NULL, yhat0=NULL, zhat0=NULL;
+    if (los_type == FIRSTPOINT_LOS) {
+        const float norm0 = sqrt(xpos*xpos + ypos*ypos + zpos*zpos);
+        xhat0 = xpos/norm0;
+        yhat0 = ypos/norm0;
+        zhat0 = zpos/norm0;
+    }
+
+    const float parx = xpos + x1pos;
+    const float pary = ypos + y1pos; 
+    const float parz = zpos + z1pos; 
+
+    const float perpx = x1pos - xpos;
+    const float perpy = y1pos - ypos;
+    const float perpz = z1pos - zpos;
+
+    //return if greater than max dz
+    if (perpz > max_dz) {
+        return;
+    }
+
+    const float sqr_s = perpx*perpx + perpy*perpy + perpz*perpz;
+    if(sqr_s >= sqr_smax || sqr_s < sqr_smin) {
+        return;
+    } 
+
+    float s = 0;
+    int mubin = nmu_bins, mubin2 = nmu_bins;
+    if (sqr_s <= 0.) {
+        mubin2 = mubin = (int) mumin_invstep;
+    } 
+    else if (los_type == MIDPOINT_LOS) {
+        const float s_dot_l = parx*perpx + pary*perpy + parz*perpz;
+        const float sqr_l = parx*parx + pary*pary + parz*parz;
+        const float sqr_mu = s_dot_l * s_dot_l / (sqr_l * sqr_s);
+        if (sqr_mu >= sqr_mumax) {
+            return;
+        } 
+        const float mu = s_dot_l >= 0 ? sqrt(sqr_mu) : -sqrt(sqr_mu);
+        mubin = (int) (mu * inv_dmu + mumin_invstep);
+        if (autocorr == 1) mubin2 = (int) (- mu * inv_dmu + mumin_invstep);
+        if(need_savg || bin_type == BIN_LIN) s = sqrt(sqr_s);
+    }
+    else {
+        const float s_dot_l = xhat0*perpx + yhat0*perpy + zhat0*perpz;
+        const float sqr_mu = s_dot_l * s_dot_l / sqr_s;
+        if (autocorr == 1) {
+            const float s_dot_l2 = xhat1*perpx + yhat1*perpy + zhat1*perpz;
+	    const float sqr_mu2 = s_dot_l2 * s_dot_l2 / sqr_s;
+	    const int skip_mu = (sqr_mu >= sqr_mumax);
+	    const int skip_mu2 = (sqr_mu2 >= sqr_mumax);
+	    if (skip_mu && skip_mu2) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    if (skip_mu == 0) mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	    if (skip_mu2 == 0) mubin2 = (int) (- s_dot_l2 / s * inv_dmu + mumin_invstep);
+	}
+	else {
+	    if (sqr_mu >= sqr_mumax) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	}
+    }
+
+    float sw = s;
+    int kbin = 0;
+    if (bin_type == BIN_LIN) {
+	kbin = (int) (s*inv_sstep + smin_invstep);
+    }
+    else {
+	for(kbin=nsbin-1;kbin>=1;kbin--) {
+	    if(sqr_s >= supp_sqr[kbin-1]) {
+		break;
+	    }
+	}//finding kbin
+    }
+    kbin *= nmu_bins+1;
+    {
+	const int ibin = kbin + mubin;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+    }
+    if (autocorr == 1) {
+	const int ibin = kbin + mubin2;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+    }
+}
+
+__global__ void countpairs_s_mu_mocks_pair_weights_kernel_double(double *x0, double *y0, double *z0,
+               double *weights0, int numweights0,
+               double *x1, double *y1, double *z1, 
+               double *weights1, int numweights1,
+               int N, int *np0, int *np1, 
+               int *same_cell, int64_t *icell0, int64_t *icell1, 
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               double *min_xdiff, double *min_ydiff, 
+               double *savg, int *npairs, double *weightavg, const double *supp_sqr,
+               const double sqr_smax, const double sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const double sqr_mumax, const double inv_dmu, const double mumin_invstep,
+               double inv_sstep, double smin_invstep,
+               int need_savg, int need_weightavg, int autocorr, int los_type, int bin_type) {
+    //thread index tidx 
+    int tidx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tidx >= N) return;
+
+    int icellpair = cellpair_lut[blockIdx.x]; //use block index to find cellpair index
+    int cell_tidx = cellthread_lut[blockIdx.x] + threadIdx.x; //index within this cellpair from 0 to np0*np1-1
+
+    //icell0, icell1 will translate icellpair to a cell within each lattice
+    //start_idx0, start_idx1 then translate to i, j in x0,y0,z0 and x1,y1,z1
+    int64_t cellindex0 = icell0[icellpair];
+    int64_t cellindex1 = icell1[icellpair];
+    //nthreads = np0 * np1 for each cell pair icell
+    int this_np0 = np0[cellindex0];
+    int this_np1 = np1[cellindex1];
+    if (cell_tidx >= this_np0*this_np1) return;
+
+    //start_idx0, start_idx1 give index for first element of x0, y0, z0 and x1, y1, z1 in cell icell.
+    //% and / to get i, j
+    int i = start_idx0[cellindex0] + cell_tidx / this_np1;
+    int j = start_idx1[cellindex1] + cell_tidx % this_np1;
+
+    //get positions for each particle
+    double xpos = x0[i];
+    double ypos = y0[i];
+    double zpos = z0[i];
+
+    double x1pos = x1[j];
+    double y1pos = y1[j];
+    double z1pos = z1[j];
+
+    if (same_cell[icellpair] && z1pos <= zpos) { 
+        //return if same particle or in same cell with z1 < z0
+        //this way we do not double count pairs
+        return;
+    }
+
+    const double max_dz = sqrt(sqr_smax - min_xdiff[icellpair]*min_xdiff[icellpair] - min_ydiff[icellpair]*min_ydiff[icellpair]);
+    const double this_dz = z1pos-zpos;
+    if (abs(this_dz) >= max_dz) {
+        //particle too far away in z
+        return;
+    }
+
+    const double this_dx = x1pos-xpos;
+    const double this_dy = y1pos-ypos;
+    if ((this_dx*this_dx + this_dy*this_dy + this_dz*this_dz) >= sqr_smax) {
+        //particle too far away in separation
+        return;
+    } 
+
+    //hat1 calcs are done if need_weightavg || ((autocorr == 1) && (los_type == FIRSTPOINT_LOS)
+    //need_weightavg is true by definition in this kernel so remove conditional
+    double xhat1=NULL, yhat1=NULL, zhat1=NULL;
+    const double norm1 = sqrt(x1pos*x1pos + y1pos*y1pos + z1pos*z1pos);
+    xhat1 = x1pos/norm1;
+    yhat1 = y1pos/norm1;
+    zhat1 = z1pos/norm1;
+
+    //hat1 calcs are done if need_weightavg || los_type == FIRSTPOINT_LOS 
+    //need_weightavg is true by definition in this kernel so remove conditional
+    double xhat0=NULL, yhat0=NULL, zhat0=NULL;
+    const double norm0 = sqrt(xpos*xpos + ypos*ypos + zpos*zpos);
+    xhat0 = xpos/norm0;
+    yhat0 = ypos/norm0;
+    zhat0 = zpos/norm0;
+
+    //need_weightavg is TRUE in this kernel BUT pair_costheta_d not used
+    //in PAIR_PRODUCT so comment out - will be used for INVERSE_BITWISE 
+    //double pair_costheta_d = xhat1*xhat0 + yhat1*yhat0 + zhat1*zhat0;
+
+    const double parx = xpos + x1pos;
+    const double pary = ypos + y1pos; 
+    const double parz = zpos + z1pos; 
+
+    const double perpx = x1pos - xpos;
+    const double perpy = y1pos - ypos;
+    const double perpz = z1pos - zpos;
+
+    //return if > max_dz
+    if (perpz > max_dz) {
+        return;
+    }
+
+    const double sqr_s = perpx*perpx + perpy*perpy + perpz*perpz;
+    if(sqr_s >= sqr_smax || sqr_s < sqr_smin) {
+        return;
+    } 
+
+    double s = 0;
+    int mubin = nmu_bins, mubin2 = nmu_bins;
+    if (sqr_s <= 0.) {
+        mubin2 = mubin = (int) mumin_invstep;
+    } 
+    else if (los_type == MIDPOINT_LOS) {
+        const double s_dot_l = parx*perpx + pary*perpy + parz*perpz;
+        const double sqr_l = parx*parx + pary*pary + parz*parz;
+        const double sqr_mu = s_dot_l * s_dot_l / (sqr_l * sqr_s);
+        if (sqr_mu >= sqr_mumax) {
+            return;
+        } 
+        const double mu = s_dot_l >= 0 ? sqrt(sqr_mu) : -sqrt(sqr_mu);
+        mubin = (int) (mu * inv_dmu + mumin_invstep);
+        if (autocorr == 1) mubin2 = (int) (- mu * inv_dmu + mumin_invstep);
+        if(need_savg || bin_type == BIN_LIN) s = sqrt(sqr_s);
+    }
+    else {
+        const double s_dot_l = xhat0*perpx + yhat0*perpy + zhat0*perpz;
+        const double sqr_mu = s_dot_l * s_dot_l / sqr_s;
+        if (autocorr == 1) {
+            const double s_dot_l2 = xhat1*perpx + yhat1*perpy + zhat1*perpz;
+	    const double sqr_mu2 = s_dot_l2 * s_dot_l2 / sqr_s;
+	    const int skip_mu = (sqr_mu >= sqr_mumax);
+	    const int skip_mu2 = (sqr_mu2 >= sqr_mumax);
+	    if (skip_mu && skip_mu2) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    if (skip_mu == 0) mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	    if (skip_mu2 == 0) mubin2 = (int) (- s_dot_l2 / s * inv_dmu + mumin_invstep);
+	}
+	else {
+	    if (sqr_mu >= sqr_mumax) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	}
+    }
+
+    double pairweight = 0; 
+    double sw = s;
+
+    //need_weightavg is TRUE so remove conditional and always calculate
+    //pairweight - only do simple PAIR_PRODUCT in this kernel
+    pairweight = weights0[i*numweights0] * weights1[j*numweights1]; 
+    if(need_savg) sw = s*pairweight;
+
+/*
+    if(need_weightavg){
+	pair.dx.d = perpx;
+	pair.dy.d = perpy;
+	pair.dz.d = perpz;
+
+	pair.parx.d = parx;
+	pair.pary.d = pary;
+	pair.parz.d = parz;
+
+	pairweight = weight_func(&pair);
+	if(need_savg) sw = s*pairweight;
+    }
+*/
+    int kbin = 0;
+    if (bin_type == BIN_LIN) {
+	kbin = (int) (s*inv_sstep + smin_invstep);
+    }
+    else {
+	for(kbin=nsbin-1;kbin>=1;kbin--) {
+	    if(sqr_s >= supp_sqr[kbin-1]) {
+		break;
+	    }
+	}//finding kbin
+    }
+    kbin *= nmu_bins+1;
+    {
+	const int ibin = kbin + mubin;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+        atomicAdd(&weightavg[ibin], pairweight); //need_weightavg is always true
+    }
+    if (autocorr == 1) {
+	const int ibin = kbin + mubin2;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+        atomicAdd(&weightavg[ibin], pairweight); //need_weightavg is always true
+    }
+}
+
+__global__ void countpairs_s_mu_mocks_pair_weights_kernel_float(float *x0, float *y0, float *z0,
+               float *weights0, int numweights0,
+               float *x1, float *y1, float *z1, 
+               float *weights1, int numweights1,
+               int N, int *np0, int *np1, 
+               int *same_cell, int64_t *icell0, int64_t *icell1, 
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               float *min_xdiff, float *min_ydiff, 
+               float *savg, int *npairs, float *weightavg, const float *supp_sqr,
+               const float sqr_smax, const float sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const float sqr_mumax, const float inv_dmu, const float mumin_invstep,
+               float inv_sstep, float smin_invstep,
+               int need_savg, int need_weightavg, int autocorr, int los_type, int bin_type) {
+    //thread index tidx 
+    int tidx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tidx >= N) return;
+
+    int icellpair = cellpair_lut[blockIdx.x]; //use block index to find cellpair index
+    int cell_tidx = cellthread_lut[blockIdx.x] + threadIdx.x; //index within this cellpair from 0 to np0*np1-1
+
+    //icell0, icell1 will translate icellpair to a cell within each lattice
+    //start_idx0, start_idx1 then translate to i, j in x0,y0,z0 and x1,y1,z1
+    int64_t cellindex0 = icell0[icellpair];
+    int64_t cellindex1 = icell1[icellpair];
+    //nthreads = np0 * np1 for each cell pair icell
+    int this_np0 = np0[cellindex0];
+    int this_np1 = np1[cellindex1];
+    if (cell_tidx >= this_np0*this_np1) return;
+
+    //start_idx0, start_idx1 give index for first element of x0, y0, z0 and x1, y1, z1 in cell icell.
+    //% and / to get i, j
+    int i = start_idx0[cellindex0] + cell_tidx / this_np1;
+    int j = start_idx1[cellindex1] + cell_tidx % this_np1;
+
+    //get positions for each particle
+    float xpos = x0[i];
+    float ypos = y0[i];
+    float zpos = z0[i];
+
+    float x1pos = x1[j];
+    float y1pos = y1[j];
+    float z1pos = z1[j];
+
+    if (same_cell[icellpair] && z1pos <= zpos) { 
+        //return if same particle or in same cell with z1 < z0
+        //this way we do not float count pairs
+        return;
+    }
+
+    const float max_dz = sqrt(sqr_smax - min_xdiff[icellpair]*min_xdiff[icellpair] - min_ydiff[icellpair]*min_ydiff[icellpair]);
+    const float this_dz = z1pos-zpos;
+    if (abs(this_dz) >= max_dz) {
+        //particle too far away in z
+        return;
+    }
+
+    const float this_dx = x1pos-xpos;
+    const float this_dy = y1pos-ypos;
+    if ((this_dx*this_dx + this_dy*this_dy + this_dz*this_dz) >= sqr_smax) {
+        //particle too far away in separation
+        return;
+    } 
+
+    //hat1 calcs are done if need_weightavg || ((autocorr == 1) && (los_type == FIRSTPOINT_LOS)
+    //need_weightavg is true by definition in this kernel so remove conditional
+    float xhat1=NULL, yhat1=NULL, zhat1=NULL;
+    const float norm1 = sqrt(x1pos*x1pos + y1pos*y1pos + z1pos*z1pos);
+    xhat1 = x1pos/norm1;
+    yhat1 = y1pos/norm1;
+    zhat1 = z1pos/norm1;
+
+    //hat1 calcs are done if need_weightavg || los_type == FIRSTPOINT_LOS 
+    //need_weightavg is true by definition in this kernel so remove conditional
+    float xhat0=NULL, yhat0=NULL, zhat0=NULL;
+    const float norm0 = sqrt(xpos*xpos + ypos*ypos + zpos*zpos);
+    xhat0 = xpos/norm0;
+    yhat0 = ypos/norm0;
+    zhat0 = zpos/norm0;
+
+    //need_weightavg is TRUE in this kernel BUT pair_costheta_d not used
+    //in PAIR_PRODUCT so comment out - will be used for INVERSE_BITWISE 
+    //float pair_costheta_d = xhat1*xhat0 + yhat1*yhat0 + zhat1*zhat0;
+
+    const float parx = xpos + x1pos;
+    const float pary = ypos + y1pos; 
+    const float parz = zpos + z1pos; 
+
+    const float perpx = x1pos - xpos;
+    const float perpy = y1pos - ypos;
+    const float perpz = z1pos - zpos;
+
+    //return if > max_dz
+    if (perpz > max_dz) {
+        return;
+    }
+
+    const float sqr_s = perpx*perpx + perpy*perpy + perpz*perpz;
+    if(sqr_s >= sqr_smax || sqr_s < sqr_smin) {
+        return;
+    } 
+
+    float s = 0;
+    int mubin = nmu_bins, mubin2 = nmu_bins;
+    if (sqr_s <= 0.) {
+        mubin2 = mubin = (int) mumin_invstep;
+    } 
+    else if (los_type == MIDPOINT_LOS) {
+        const float s_dot_l = parx*perpx + pary*perpy + parz*perpz;
+        const float sqr_l = parx*parx + pary*pary + parz*parz;
+        const float sqr_mu = s_dot_l * s_dot_l / (sqr_l * sqr_s);
+        if (sqr_mu >= sqr_mumax) {
+            return;
+        } 
+        const float mu = s_dot_l >= 0 ? sqrt(sqr_mu) : -sqrt(sqr_mu);
+        mubin = (int) (mu * inv_dmu + mumin_invstep);
+        if (autocorr == 1) mubin2 = (int) (- mu * inv_dmu + mumin_invstep);
+        if(need_savg || bin_type == BIN_LIN) s = sqrt(sqr_s);
+    }
+    else {
+        const float s_dot_l = xhat0*perpx + yhat0*perpy + zhat0*perpz;
+        const float sqr_mu = s_dot_l * s_dot_l / sqr_s;
+        if (autocorr == 1) {
+            const float s_dot_l2 = xhat1*perpx + yhat1*perpy + zhat1*perpz;
+	    const float sqr_mu2 = s_dot_l2 * s_dot_l2 / sqr_s;
+	    const int skip_mu = (sqr_mu >= sqr_mumax);
+	    const int skip_mu2 = (sqr_mu2 >= sqr_mumax);
+	    if (skip_mu && skip_mu2) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    if (skip_mu == 0) mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	    if (skip_mu2 == 0) mubin2 = (int) (- s_dot_l2 / s * inv_dmu + mumin_invstep);
+	}
+	else {
+	    if (sqr_mu >= sqr_mumax) {
+                return;
+            } 
+	    s = sqrt(sqr_s);
+	    mubin = (int) (s_dot_l / s * inv_dmu + mumin_invstep);
+	}
+    }
+
+    float pairweight = 0; 
+    float sw = s;
+
+    //need_weightavg is TRUE so remove conditional and always calculate
+    //pairweight - only do simple PAIR_PRODUCT in this kernel
+    pairweight = weights0[i*numweights0] * weights1[j*numweights1]; 
+    if(need_savg) sw = s*pairweight;
+
+/*
+    if(need_weightavg){
+	pair.dx.d = perpx;
+	pair.dy.d = perpy;
+	pair.dz.d = perpz;
+
+	pair.parx.d = parx;
+	pair.pary.d = pary;
+	pair.parz.d = parz;
+
+	pairweight = weight_func(&pair);
+	if(need_savg) sw = s*pairweight;
+    }
+*/
+    int kbin = 0;
+    if (bin_type == BIN_LIN) {
+	kbin = (int) (s*inv_sstep + smin_invstep);
+    }
+    else {
+	for(kbin=nsbin-1;kbin>=1;kbin--) {
+	    if(sqr_s >= supp_sqr[kbin-1]) {
+		break;
+	    }
+	}//finding kbin
+    }
+    kbin *= nmu_bins+1;
+    {
+	const int ibin = kbin + mubin;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+        atomicAdd(&weightavg[ibin], pairweight); //need_weightavg is always true
+    }
+    if (autocorr == 1) {
+	const int ibin = kbin + mubin2;
+        //use atomic add to guarantee atomicity
+        atomicAdd(&npairs[ibin], 1);
+        if (need_savg) atomicAdd(&savg[ibin], sw);
+        atomicAdd(&weightavg[ibin], pairweight); //need_weightavg is always true
+    }
+}
+
+extern "C" {
+
+//=================== ALLOCATE METHODS =============== //
+
+// ---------- ints ----------
+
+void gpu_allocate_block_luts(int **p_gpu_cellpair_lut, int **p_gpu_cellthread_lut, const int numblocks) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_cellpair_lut), numblocks*sizeof(int));
+    cudaMallocManaged(&(*p_gpu_cellthread_lut), numblocks*sizeof(int));
+}
+
+void gpu_allocate_cell_luts(int **p_gpu_same_cell, int64_t **p_gpu_icell0, int64_t **p_gpu_icell1, const int64_t num_cell_pairs) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_same_cell), num_cell_pairs*sizeof(int));
+    cudaMallocManaged(&(*p_gpu_icell0), num_cell_pairs*sizeof(int64_t));
+    cudaMallocManaged(&(*p_gpu_icell1), num_cell_pairs*sizeof(int64_t));
+}
+
+void gpu_allocate_lattice_luts(int **p_gpu_np, int **p_gpu_start_idx, const int64_t num_cells) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_np), num_cells*sizeof(int));
+    cudaMallocManaged(&(*p_gpu_start_idx), num_cells*sizeof(int));
+}
+
+
+// ----------- doubles --------------
+
+void gpu_allocate_mins_double(double **p_gpu_min_dx, double **p_gpu_min_dy, const int64_t num_cell_pairs) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_min_dx), num_cell_pairs*sizeof(double));
+    cudaMallocManaged(&(*p_gpu_min_dy), num_cell_pairs*sizeof(double));
+}   
+
+void gpu_allocate_mocks_double(double **p_X1, double **p_Y1, double **p_Z1, const int64_t ND1) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_X1), ND1*sizeof(double));
+    cudaMallocManaged(&(*p_Y1), ND1*sizeof(double));
+    cudaMallocManaged(&(*p_Z1), ND1*sizeof(double));
+}
+
+void gpu_allocate_outputs_double(double **p_gpu_savg, int **p_gpu_npairs, const int totnbins) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_savg), totnbins*sizeof(double));
+    cudaMallocManaged(&(*p_gpu_npairs), totnbins*sizeof(int));
+}
+
+void gpu_allocate_supp_sqr_double(double **p_gpu_supp_sqr, const int nsbin) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_supp_sqr), nsbin*sizeof(double));
+}
+
+void gpu_allocate_weight_output_double(double **p_gpu_weightavg, const int totnbins) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_weightavg), totnbins*sizeof(double));
+}
+
+void gpu_allocate_weights_double(double **p_weights, const int64_t ND1, uint8_t num_weights) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_weights), ND1*num_weights*sizeof(double));
+}
+
+// --------------- floats --------------- //
+
+void gpu_allocate_mins_float(float **p_gpu_min_dx, float **p_gpu_min_dy, const int64_t num_cell_pairs) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_min_dx), num_cell_pairs*sizeof(float));
+    cudaMallocManaged(&(*p_gpu_min_dy), num_cell_pairs*sizeof(float));
+}
+
+void gpu_allocate_mocks_float(float **p_X1, float **p_Y1, float **p_Z1, const int64_t ND1) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_X1), ND1*sizeof(float));
+    cudaMallocManaged(&(*p_Y1), ND1*sizeof(float));
+    cudaMallocManaged(&(*p_Z1), ND1*sizeof(float));
+}
+
+void gpu_allocate_outputs_float(float **p_gpu_savg, int **p_gpu_npairs, const int totnbins) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_savg), totnbins*sizeof(float));
+    cudaMallocManaged(&(*p_gpu_npairs), totnbins*sizeof(int));
+}
+
+void gpu_allocate_supp_sqr_float(float **p_gpu_supp_sqr, const int nsbin) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_supp_sqr), nsbin*sizeof(float));
+}
+
+void gpu_allocate_weight_output_float(float **p_gpu_weightavg, const int totnbins) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_gpu_weightavg), totnbins*sizeof(float));
+}
+
+void gpu_allocate_weights_float(float **p_weights, const int64_t ND1, uint8_t num_weights) {
+    // Allocate Unified Memory – accessible from CPU or GPU
+    // Takes pointers as args
+    cudaMallocManaged(&(*p_weights), ND1*num_weights*sizeof(float));
+}
+
+// ============  FREE MEMORY ============= //
+
+// ---------- ints ----------
+void gpu_free_block_luts(int *gpu_cellpair_lut, int *gpu_cellthread_lut) {
+    cudaFree(gpu_cellpair_lut);
+    cudaFree(gpu_cellthread_lut);
+}
+
+void gpu_free_cell_luts(int *gpu_same_cell, int64_t *gpu_icell0, int64_t *gpu_icell1) {
+    cudaFree(gpu_same_cell);
+    cudaFree(gpu_icell0);
+    cudaFree(gpu_icell1);
+}
+
+void gpu_free_lattice_luts(int *gpu_np, int *gpu_start_idx) {
+    cudaFree(gpu_np);
+    cudaFree(gpu_start_idx);
+}
+
+// ----------- doubles --------------
+
+void gpu_free_mins_double(double *gpu_min_dx, double *gpu_min_dy) {
+    cudaFree(gpu_min_dx);
+    cudaFree(gpu_min_dy);
+}
+
+void gpu_free_mocks_double(double *X1, double *Y1, double *Z1) {
+    cudaFree(X1);
+    cudaFree(Y1);
+    cudaFree(Z1);
+}
+
+void gpu_free_outputs_double(double *gpu_savg, int *gpu_npairs) {
+    cudaFree(gpu_savg);
+    cudaFree(gpu_npairs);
+}
+
+void gpu_free_supp_sqr_double(double *gpu_supp_sqr) {
+    cudaFree(gpu_supp_sqr);
+}
+
+void gpu_free_weight_output_double(double *gpu_weightavg) {
+    cudaFree(gpu_weightavg);
+}
+
+void gpu_free_weights_double(double *weights) {
+    cudaFree(weights);
+}
+
+// --------------- floats --------------- //
+
+void gpu_free_mins_float(float *gpu_min_dx, float *gpu_min_dy) {
+    cudaFree(gpu_min_dx);
+    cudaFree(gpu_min_dy);
+}
+
+void gpu_free_mocks_float(float *X1, float *Y1, float *Z1) {
+    cudaFree(X1);
+    cudaFree(Y1);
+    cudaFree(Z1);
+}
+
+void gpu_free_outputs_float(float *gpu_savg, int *gpu_npairs) {
+    cudaFree(gpu_savg);
+    cudaFree(gpu_npairs);
+}
+
+void gpu_free_supp_sqr_float(float *gpu_supp_sqr) {
+    cudaFree(gpu_supp_sqr);
+}
+
+void gpu_free_weight_output_float(float *gpu_weightavg) {
+    cudaFree(gpu_weightavg);
+}
+
+void gpu_free_weights_float(float *weights) {
+    cudaFree(weights);
+}
+
+//==========================//
+
+
+void gpu_device_synchronize() {
+  // Wait for GPU to finish before accessing on host
+  //This does not need to be called after every kernel invocation,
+  //but just before memory is accessed on host
+  cudaDeviceSynchronize();
+}
+
+// =========   Kernel called below ============//
+
+int gpu_batch_countpairs_s_mu_mocks_double(double *x0, double *y0, double *z0,
+               double *weights0, uint8_t numweights0,
+               double *x1, double *y1, double *z1, 
+               double *weights1, uint8_t numweights1,
+               const int N, int *np0, int *np1,
+               int *same_cell, int64_t *icell0, int64_t *icell1,
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               double *min_xdiff, double *min_ydiff, 
+               double *savg, int *npairs, double *weightavg, const double *supp_sqr,
+               const double sqr_smax, const double sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const double sqr_mumax, const double inv_dmu, const double mumin_invstep,
+               double inv_sstep, double smin_invstep,
+               int need_savg, const weight_method_t weight_method, int autocorr, int los_type, int bin_type) {
+    long threads = N;
+    int blocksPerGrid = (threads+THREADS_PER_BLOCK-1) / THREADS_PER_BLOCK;
+
+    //select kernel based on weight_method - faster to have a base kernel that
+    //is not unnecessarily passed extra arrays for weighting calcs that won't
+    //be performed
+
+    if (weight_method == PAIR_PRODUCT) {
+        countpairs_s_mu_mocks_pair_weights_kernel_double<<<blocksPerGrid, THREADS_PER_BLOCK>>>(
+            x0, y0, z0, weights0, (int)numweights0,
+            x1, y1, z1, weights1, (int)numweights1,
+            N, np0, np1,
+            same_cell, icell0, icell1,
+            cellpair_lut, cellthread_lut,
+            start_idx0, start_idx1,
+            min_xdiff, min_ydiff, 
+            savg, npairs, weightavg, supp_sqr,
+            sqr_smax, sqr_smin, nsbin, nmu_bins,
+            sqr_mumax,inv_dmu,mumin_invstep,
+            inv_sstep, smin_invstep,
+            need_savg, 1, autocorr, los_type, bin_type);
+    } else {
+        countpairs_s_mu_mocks_kernel_double<<<blocksPerGrid, THREADS_PER_BLOCK>>>(
+            x0, y0, z0,
+            x1, y1, z1, N,
+            np0, np1, 
+            same_cell, icell0, icell1, 
+            cellpair_lut, cellthread_lut,
+            start_idx0, start_idx1,
+            min_xdiff, min_ydiff, 
+            savg, npairs, supp_sqr,
+            sqr_smax, sqr_smin, nsbin, nmu_bins, 
+            sqr_mumax,inv_dmu,mumin_invstep,
+            inv_sstep, smin_invstep,
+            need_savg, autocorr, los_type, bin_type);
+    }
+
+    //synchronize memory after kernel call
+    cudaDeviceSynchronize();
+//    gpu_print_cuda_error();
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}
+
+// ----------- float version ----------------
+
+int gpu_batch_countpairs_s_mu_mocks_float(float *x0, float *y0, float *z0,
+               float *weights0, uint8_t numweights0,
+               float *x1, float *y1, float *z1,
+               float *weights1, uint8_t numweights1,
+               const int N, int *np0, int *np1,
+               int *same_cell, int64_t *icell0, int64_t *icell1,
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               float *min_xdiff, float *min_ydiff,
+               float *savg, int *npairs, float *weightavg, const float *supp_sqr,
+               const float sqr_smax, const float sqr_smin, const int nsbin,
+               const int nmu_bins,
+               const float sqr_mumax, const float inv_dmu, const float mumin_invstep,
+               float inv_sstep, float smin_invstep,
+               int need_savg, const weight_method_t weight_method, int autocorr, int los_type, int bin_type) {
+    long threads = N;
+    int blocksPerGrid = (threads+THREADS_PER_BLOCK-1) / THREADS_PER_BLOCK;
+
+    //select kernel based on weight_method - faster to have a base kernel that
+    //is not unnecessarily passed extra arrays for weighting calcs that won't
+    //be performed
+
+    if (weight_method == PAIR_PRODUCT) {
+        countpairs_s_mu_mocks_pair_weights_kernel_float<<<blocksPerGrid, THREADS_PER_BLOCK>>>(
+            x0, y0, z0, weights0, (int)numweights0,
+            x1, y1, z1, weights1, (int)numweights1,
+            N, np0, np1,
+            same_cell, icell0, icell1,
+            cellpair_lut, cellthread_lut,
+            start_idx0, start_idx1,
+            min_xdiff, min_ydiff,
+            savg, npairs, weightavg, supp_sqr,
+            sqr_smax, sqr_smin, nsbin, nmu_bins,
+            sqr_mumax,inv_dmu,mumin_invstep,
+            inv_sstep, smin_invstep,
+            need_savg, 1, autocorr, los_type, bin_type);
+    } else {
+        countpairs_s_mu_mocks_kernel_float<<<blocksPerGrid, THREADS_PER_BLOCK>>>(
+            x0, y0, z0,
+            x1, y1, z1, N,
+            np0, np1,
+            same_cell, icell0, icell1,
+            cellpair_lut, cellthread_lut,
+            start_idx0, start_idx1,
+            min_xdiff, min_ydiff,
+            savg, npairs, supp_sqr,
+            sqr_smax, sqr_smin, nsbin, nmu_bins,
+            sqr_mumax,inv_dmu,mumin_invstep,
+            inv_sstep, smin_invstep,
+            need_savg, autocorr, los_type, bin_type);
+    }
+
+    //synchronize memory after kernel call
+    cudaDeviceSynchronize();
+//    gpu_print_cuda_error();
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}
+
+
+void gpu_print_cuda_error() {
+       size_t free_byte ;
+
+        size_t total_byte ;
+
+        cudaError_t cuda_status = cudaMemGetInfo( &free_byte, &total_byte ) ;
+
+        if ( cudaSuccess != cuda_status ){
+
+            printf("Error: cudaMemGetInfo fails, %s \n", cudaGetErrorString(cuda_status) );
+
+            exit(1);
+
+        }
+
+        double free_db = (double)free_byte ;
+        double total_db = (double)total_byte ;
+        double used_db = total_db - free_db ;
+
+        printf("GPU memory usage: used = %f, free = %f MB, total = %f MB\n",
+
+        used_db/1024.0/1024.0, free_db/1024.0/1024.0, total_db/1024.0/1024.0);
+
+        cudaError_t err = cudaGetLastError();
+        printf("CUDA Error: %s\n", cudaGetErrorString(err));
+}
+
+//==============================================
+}

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.h
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_gpu.h
@@ -1,0 +1,94 @@
+// # -*- mode: c -*-
+#pragma once
+#define THREADS_PER_BLOCK 512
+
+//=================== ALLOCATE METHODS =============== //
+
+//ints -- these are the same for double and float versions
+void gpu_allocate_block_luts(int **p_gpu_cellpair_lut, int **p_gpu_cellthread_lut, const int numblocks);
+void gpu_allocate_cell_luts(int **p_gpu_same_cell, int64_t **p_gpu_icell0, int64_t **p_gpu_icell1, const int64_t num_cell_pairs);
+void gpu_allocate_lattice_luts(int **p_gpu_np, int **p_gpu_start_idx, const int64_t num_cells);
+
+//doubles
+void gpu_allocate_mins_double(double **p_gpu_min_dx, double **p_gpu_min_dy, const int64_t num_cell_pairs);
+void gpu_allocate_mocks_double(double **p_X1, double **p_Y1, double **p_Z1, const int64_t ND1);
+void gpu_allocate_outputs_double(double **p_gpu_savg, int **p_gpu_npairs, const int totnbins);
+void gpu_allocate_supp_sqr_double(double **p_gpu_supp_sqr, const int nsbin);
+void gpu_allocate_weight_output_double(double **p_gpu_weightavg, const int totnbins);
+void gpu_allocate_weights_double(double **p_weights, const int64_t ND1, uint8_t num_weights);
+
+
+//floats
+void gpu_allocate_mins_float(float **p_gpu_min_dx, float **p_gpu_min_dy, const int64_t num_cell_pairs);
+void gpu_allocate_mocks_float(float **p_X1, float **p_Y1, float **p_Z1, const int64_t ND1);
+void gpu_allocate_outputs_float(float **p_gpu_savg, int **p_gpu_npairs, const int totnbins);
+void gpu_allocate_supp_sqr_float(float **p_gpu_supp_sqr, const int nsbin);
+void gpu_allocate_weight_output_float(float **p_gpu_weightavg, const int totnbins);
+void gpu_allocate_weights_float(float **p_weights, const int64_t ND1, uint8_t num_weights);
+
+
+
+//=================== FREE MEMORY =============== //
+
+//ints -- these are the same for double and float versions
+void gpu_free_block_luts(int *gpu_cellpair_lut, int *gpu_cellthread_lut);
+void gpu_free_cell_luts(int *gpu_same_cell, int64_t *gpu_icell0, int64_t *gpu_icell1);
+void gpu_free_lattice_luts(int *gpu_np, int *gpu_start_idx);
+
+
+//doubles
+void gpu_free_closests_double(double *gpu_closest_x1, double *gpu_closest_y1, double *gpu_closest_z1);
+void gpu_free_mins_double(double *gpu_min_dx, double *gpu_min_dy);
+void gpu_free_mocks_double(double *X1, double *Y1, double *Z1);
+void gpu_free_outputs_double(double *gpu_savg, int *gpu_npairs);
+void gpu_free_supp_sqr_double(double *gpu_supp_sqr);
+void gpu_free_weight_output_double(double *gpu_weightavg);
+void gpu_free_weights_double(double *weights);
+
+//floats
+void gpu_free_closests_float(float *gpu_closest_x1, float *gpu_closest_y1, float *gpu_closest_z1);
+void gpu_free_mins_float(float *gpu_min_dx, float *gpu_min_dy);
+void gpu_free_mocks_float(float *X1, float *Y1, float *Z1);
+void gpu_free_outputs_float(float *gpu_savg, int *gpu_npairs);
+void gpu_free_supp_sqr_float(float *gpu_supp_sqr);
+void gpu_free_weight_output_float(float *gpu_weightavg);
+void gpu_free_weights_float(float *weights);
+
+
+// ================== KERNEL =================== /
+
+int gpu_batch_countpairs_s_mu_mocks_double(double *x0, double *y0, double *z0, double *weights0, uint8_t nw0,
+               double *x1, double *y1, double *z1, double *weights1, uint8_t nw1,
+               const int N, int *np0, int *np1, 
+               int *same_cell, int64_t *icell0, int64_t *icell1,
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               double *min_xdiff, double *min_ydiff, 
+               double *savg, int *npairs, double *weightavg, const double *supp_sqr,
+               const double sqr_smax, const double sqr_smin, const int nsbin,
+               const int nmu_bins, 
+               const double sqr_mumax, const double inv_dmu, const double mumin_invstep,
+               double inv_sstep, double smin_invstep,
+               int need_savg, const weight_method_t weight_method, int autocorr, int los_type, int bin_type);
+
+
+int gpu_batch_countpairs_s_mu_mocks_float(float *x0, float *y0, float *z0, float *weights0, uint8_t nw0,
+               float *x1, float *y1, float *z1, float *weights1, uint8_t nw1,
+               const int N, int *np0, int *np1,
+               int *same_cell, int64_t *icell0, int64_t *icell1,
+               int *cellpair_lut, int *cellthread_lut,
+               int *start_idx0, int *start_idx1,
+               float *min_xdiff, float *min_ydiff,
+               float *savg, int *npairs, float *weightavg, const float *supp_sqr,
+               const float sqr_smax, const float sqr_smin, const int nsbin,
+               const int nmu_bins,
+               const float sqr_mumax, const float inv_dmu, const float mumin_invstep,
+               float inv_sstep, float smin_invstep,
+               int need_savg, const weight_method_t weight_method, int autocorr, int los_type, int bin_type);
+
+// ======================================================= /
+// call cudaDeviceSynchronize
+
+void gpu_device_synchronize();
+
+void gpu_print_cuda_error();

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -28,6 +28,9 @@
 #include "countpairs_s_mu_mocks_impl_DOUBLE.h"
 #include "countpairs_s_mu_mocks_kernels_DOUBLE.c"
 
+#ifdef GPU
+#include "countpairs_s_mu_mocks_gpu.h"
+#endif
 
 int interrupt_status_DDsmu_mocks_DOUBLE=EXIT_SUCCESS;
 
@@ -116,6 +119,11 @@ countpairs_mocks_func_ptr_DOUBLE countpairs_s_mu_mocks_driver_DOUBLE(const struc
 
     if(options->verbose){
         // Must be ordered low to high, since higher ISA may be aliased to lower ones
+#ifdef GPU
+        if (options->use_gpu) {
+            fprintf(stderr,"Using GPU kernel\n");
+        } else
+#endif
         if(function_dispatch == fallback_index){
             fprintf(stderr,"Using fallback kernel\n");
         } else if(function_dispatch == sse_index){
@@ -150,6 +158,8 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
                 __FUNCTION__, sizeof(DOUBLE), options->float_type);
         return EXIT_FAILURE;
     }
+
+    bool use_gpu = (bool)options->use_gpu;
 
 
     /***********************
@@ -403,6 +413,27 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         init_my_progressbar(num_cell_pairs, &interrupted);
     }
 
+#ifdef GPU
+    //declare GPU arrays here - there's no real penalty if use_gpu is false, they never get allocated
+    DOUBLE *gpu_X1, *gpu_Y1, *gpu_Z1;
+    DOUBLE *gpu_X2, *gpu_Y2, *gpu_Z2;
+    DOUBLE *gpu_W1, *gpu_W2;
+
+    DOUBLE *gpu_min_dx, *gpu_min_dy; //min_dz not needed for GPU kernel
+
+    DOUBLE *gpu_savg;
+    DOUBLE *gpu_weightavg, *gpu_supp_sqr;
+
+    int *gpu_same_cell;
+    int64_t *gpu_icell0, *gpu_icell1;
+    int *gpu_np0, *gpu_np1;
+    int *gpu_start_idx0, *gpu_start_idx1;
+
+    uint8_t nw1 = (extra->weights0).num_weights;
+    uint8_t nw2 = (extra->weights1).num_weights;
+
+    int *gpu_npairs;
+#endif
 
 #if defined(_OPENMP)
 #pragma omp parallel shared(numdone, abort_status, interrupt_status_DDsmu_mocks_DOUBLE)
@@ -417,6 +448,11 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         if(need_weightavg) {
             this_weightavg = all_weightavg[tid];
         }
+/*
+#ifdef GPU
+        setCudaDevice(tid);
+#endif
+*/
 #else
         uint64_t *this_npairs = npairs;
         DOUBLE *this_savg = savg;
@@ -427,45 +463,138 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         if(options->need_avg_sep) tmp_savg = (DOUBLE *) malloc(sizeof(DOUBLE)*totnbins);
         if(need_weightavg) tmp_weightavg = (DOUBLE *) malloc(sizeof(DOUBLE)*totnbins);
 
+#ifdef GPU
+        if (use_gpu) {
+                //gpu_print_cuda_error();
+                gpu_allocate_mocks_DOUBLE(&gpu_X1, &gpu_Y1, &gpu_Z1, ND1);
+                gpu_allocate_mocks_DOUBLE(&gpu_X2, &gpu_Y2, &gpu_Z2, ND2);
+                gpu_allocate_mins_DOUBLE(&gpu_min_dx, &gpu_min_dy, num_cell_pairs);
+                gpu_allocate_cell_luts(&gpu_same_cell, &gpu_icell0, &gpu_icell1, num_cell_pairs);
+                gpu_allocate_lattice_luts(&gpu_np0, &gpu_start_idx0, totncells);
+                gpu_allocate_lattice_luts(&gpu_np1, &gpu_start_idx1, totncells);
+                if (nw1 > 0) gpu_allocate_weights_DOUBLE(&gpu_W1, ND1, nw1);
+                if (nw2 > 0) gpu_allocate_weights_DOUBLE(&gpu_W2, ND2, nw2);
+
+                gpu_allocate_outputs_DOUBLE(&gpu_savg, &gpu_npairs, totnbins);
+                if (need_weightavg) gpu_allocate_weight_output_DOUBLE(&gpu_weightavg, totnbins);
+                gpu_allocate_supp_sqr_DOUBLE(&gpu_supp_sqr, nsbin);
+
+                for (int i = 0; i < nsbin; i++) gpu_supp_sqr[i] = supp_sqr[i];
+
+                //loop over cell pairs and populate GPU arrays
+                int64_t tcount = 0; //thread count
+                int64_t icell1, icell2;
+                int64_t maxc = 0, minc = 0;
+                int64_t this_count = 0;
+                for(int64_t icellpair=0;icellpair<num_cell_pairs;icellpair++) {
+                        struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[icellpair];
+                        gpu_min_dx[icellpair] = this_cell_pair->min_dx;
+                        gpu_min_dy[icellpair] = this_cell_pair->min_dy;
+                        //gpu_min_dz[icellpair] = this_cell_pair->min_dz;
+                        gpu_same_cell[icellpair] = (int)this_cell_pair->same_cell;
+                        icell1 = this_cell_pair->cellindex1;
+                        icell2 = this_cell_pair->cellindex2;
+                        gpu_icell0[icellpair] = icell1;
+                        gpu_icell1[icellpair] = icell2;
+                        //thread count is total number of inner loop iterations
+                        this_count = (&lattice1[icell1])->nelements * (&lattice2[icell2])->nelements;
+                        tcount += this_count;
+                        if (this_count > maxc) maxc= this_count;
+                        if (minc == 0 || this_count < minc) minc = this_count;
+                }
+
+                //loop over lattices and populate LUTs
+                int pcount1 = 0, pcount2 = 0;
+                int64_t i1 = 0, i2 = 0;
+                for (int64_t icell = 0; icell<totncells; icell++) {
+                        gpu_np0[icell] = (&lattice1[icell])->nelements;
+                        gpu_np1[icell] = (&lattice2[icell])->nelements;
+                        gpu_start_idx0[icell] = pcount1;
+                        gpu_start_idx1[icell] = pcount2;
+                        pcount1 += (&lattice1[icell])->nelements;
+                        pcount2 += (&lattice2[icell])->nelements;
+                        const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                        const cellarray_mocks_DOUBLE *second = &lattice2[icell];
+                        //loop over elements in first, second cells
+                        for (int i_first = 0; i_first < first->nelements; i_first++) {
+                                //loop over weights if nw1 > 0 and copy them
+                                for (int i_w = 0; i_w < nw1; i_w++) {
+                                    gpu_W1[i1*nw1+i_w] = first->weights.weights[i_w][i_first];
+                                }
+                                gpu_X1[i1] = first->x[i_first];
+                                gpu_Y1[i1] = first->y[i_first];
+                                gpu_Z1[i1++] = first->z[i_first];
+                        }
+                        for (int i_second = 0; i_second < second->nelements; i_second++) {
+                                //loop over weights if nw1 > 1 and copy them
+                                for (int i_w = 0; i_w < nw2; i_w++) {
+                                    gpu_W2[i2*nw2+i_w] = second->weights.weights[i_w][i_second];
+                                }
+                                gpu_X2[i2] = second->x[i_second];
+                                gpu_Y2[i2] = second->y[i_second];
+                                gpu_Z2[i2++] = second->z[i_second];
+                        }
+                }
+
+        }
+#endif
+
+#ifdef GPU
+        if (use_gpu) {
+                //if using GPU, call GPU version of countpairs_s_mu_mocks_gpu_DOUBLE here
+                const int status = countpairs_s_mu_mocks_gpu_DOUBLE(ND1, gpu_X1, gpu_Y1, gpu_Z1, gpu_W1, nw1,
+                                                                         ND2, gpu_X2, gpu_Y2, gpu_Z2, gpu_W2, nw2,
+                                                                         gpu_same_cell,
+                                                                         gpu_icell0, gpu_icell1, num_cell_pairs,
+                                                                         gpu_np0, gpu_np1, gpu_start_idx0, gpu_start_idx1,
+                                                                         smax, smin, nsbin, nmu_bins, gpu_supp_sqr, mu_max,
+                                                                         gpu_min_dx, gpu_min_dy,
+                                                                         gpu_savg, gpu_npairs,
+                                                                         gpu_weightavg, extra->weight_method, options->bin_type, options->los_type, autocorr);
+                abort_status |= status;
+        } else {
+#endif
+
+
 #if defined(_OPENMP)
 #pragma omp for schedule(dynamic)
 #endif
-        /*---Loop-over-all-cell-pairs--------------------*/
-        for(int64_t icellpair=0;icellpair<num_cell_pairs;icellpair++) {
+            /*---Loop-over-all-cell-pairs--------------------*/
+            for(int64_t icellpair=0;icellpair<num_cell_pairs;icellpair++) {
 #if defined(_OPENMP)
 #pragma omp flush (abort_status, interrupt_status_DDsmu_mocks_DOUBLE)
 #endif
-            if(abort_status == EXIT_SUCCESS && interrupt_status_DDsmu_mocks_DOUBLE == EXIT_SUCCESS) {
-                //omp cancel was introduced in omp 4.0 - so this is my way of checking if loop needs to be cancelled
-                /* If the verbose option is not enabled, avoid outputting anything unnecessary*/
-                if(options->verbose) {
+                if(abort_status == EXIT_SUCCESS && interrupt_status_DDsmu_mocks_DOUBLE == EXIT_SUCCESS) {
+                    //omp cancel was introduced in omp 4.0 - so this is my way of checking if loop needs to be cancelled
+                    /* If the verbose option is not enabled, avoid outputting anything unnecessary*/
+                    if(options->verbose) {
 #if defined(_OPENMP)
-                    if (omp_get_thread_num() == 0)
+                        if (omp_get_thread_num() == 0)
 #endif
-                        my_progressbar(numdone,&interrupted);
+                            my_progressbar(numdone,&interrupted);
 
 
 #if defined(_OPENMP)
 #pragma omp atomic
 #endif
-                    numdone++;
-                }
+                        numdone++;
+                    }
 
-                struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[icellpair];
+                    struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[icellpair];
 
-                const int64_t icell = this_cell_pair->cellindex1;
-                const int64_t icell2 = this_cell_pair->cellindex2;
-                const cellarray_mocks_DOUBLE *first = &lattice1[icell];
-                const cellarray_mocks_DOUBLE *second = &lattice2[icell2];
+                    const int64_t icell = this_cell_pair->cellindex1;
+                    const int64_t icell2 = this_cell_pair->cellindex2;
+                    const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                    const cellarray_mocks_DOUBLE *second = &lattice2[icell2];
 
-                if(options->need_avg_sep) {
-                    for(int j=0;j<totnbins;j++) tmp_savg[j] = 0.;
-                }
-                if(need_weightavg) {
-                    for(int j=0;j<totnbins;j++) tmp_weightavg[j] = 0.;
-                }
+                    if(options->need_avg_sep) {
+                        for(int j=0;j<totnbins;j++) tmp_savg[j] = 0.;
+                    }
+                    if(need_weightavg) {
+                        for(int j=0;j<totnbins;j++) tmp_weightavg[j] = 0.;
+                    }
 
-                const int status = countpairs_s_mu_mocks_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                    const int status = countpairs_s_mu_mocks_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
                                                                          second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                          this_cell_pair->same_cell,
                                                                          options->fast_divide_and_NR_steps,
@@ -475,26 +604,62 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
                                                                          tmp_savg, this_npairs, tmp_weightavg,
                                                                          extra->weight_method, extra->pair_weight, options->selection, options->bin_type, options->los_type, autocorr);
 
-                /* This actually causes a race condition under OpenMP - but mostly
-                   I care that an error occurred - rather than the exact value of
-                   the error status */
-                abort_status |= status;
+                    /* This actually causes a race condition under OpenMP - but mostly
+                       I care that an error occurred - rather than the exact value of
+                       the error status */
+                    abort_status |= status;
 
-                if(options->need_avg_sep) {
-                    for(int j=0;j<totnbins;j++) this_savg[j] += tmp_savg[j];
-                }
-                if(need_weightavg) {
-                    for(int j=0;j<totnbins;j++) this_weightavg[j] += tmp_weightavg[j];
-                }
+                    if(options->need_avg_sep) {
+                        for(int j=0;j<totnbins;j++) this_savg[j] += tmp_savg[j];
+                    }
+                    if(need_weightavg) {
+                        for(int j=0;j<totnbins;j++) this_weightavg[j] += tmp_weightavg[j];
+                    }
 
-            }//abort-status
-        }//icellpair loop over num_cell_pairs
+                }//abort-status
+            }//icellpair loop over num_cell_pairs
+#ifdef GPU
+        //end if-else block in GPU mode
+        }
+#endif
+
     free(tmp_savg);
     free(tmp_weightavg);
 #if defined(_OPENMP)
     }//close the omp parallel region
 #endif//USE_OMP
     free(all_cell_pairs);
+
+#ifdef GPU
+    //Free memory and copy outputs back to CPU
+    if (use_gpu) {
+        gpu_free_mocks_DOUBLE(gpu_X1, gpu_Y1, gpu_Z1);
+        gpu_free_mocks_DOUBLE(gpu_X2, gpu_Y2, gpu_Z2);
+        gpu_free_mins_DOUBLE(gpu_min_dx, gpu_min_dy);
+        gpu_free_cell_luts(gpu_same_cell, gpu_icell0, gpu_icell1);
+        gpu_free_lattice_luts(gpu_np0, gpu_start_idx0);
+        gpu_free_lattice_luts(gpu_np1, gpu_start_idx1);
+        gpu_free_supp_sqr_DOUBLE(gpu_supp_sqr);
+
+        //Copy outputs back to CPU
+        for (int j = 0; j < totnbins; j++) {
+            npairs[j] = (uint64_t)gpu_npairs[j];
+        }
+        if(options->need_avg_sep) {
+            for (int j = 0; j < totnbins; j++) {
+                savg[j] = gpu_savg[j];
+            }
+        }
+        gpu_free_outputs_DOUBLE(gpu_savg, gpu_npairs);
+
+        if (need_weightavg) {
+            for (int j = 0; j < totnbins; j++) {
+                weightavg[j] = gpu_weightavg[j];
+            }
+            gpu_free_weight_output_DOUBLE(gpu_weightavg);
+        }
+    }
+#endif
 
     if(options->copy_particles == 0) {
         int64_t *original_index = lattice1[0].original_index;

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -575,7 +575,7 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
                                                                          gpu_min_dx, gpu_min_dy,
                                                                          gpu_savg, gpu_npairs,
                                                                          gpu_weightavg, extra->weight_method, options->bin_type, options->los_type, autocorr,
-                                                                         gpu_cellpair_lut, gpu_cellthread_lut);
+                                                                         gpu_cellpair_lut, gpu_cellthread_lut, options->verbose);
                 abort_status |= status;
             }
         } else {

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -505,7 +505,6 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
                         gpu_Z2[i2++] = second->z[i_second];
                 }
         }
-
     }
 #endif
 
@@ -534,9 +533,14 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
 
 #ifdef GPU
 #if defined(_OPENMP)
-        int64_t cellpair_start = tid*num_cell_pairs/numthreads;
-        int64_t cellpair_end = (tid+1)*num_cell_pairs/numthreads;
-        if (use_gpu) {
+        //check n gpu so as to not crash if more threads than GPU are specified
+        int ngpu;
+        cudaGetDeviceCount(&ngpu);
+        int gputhreads = numthreads;
+        if (gputhreads > ngpu) gputhreads = ngpu;
+        int64_t cellpair_start = tid*num_cell_pairs/gputhreads;
+        int64_t cellpair_end = (tid+1)*num_cell_pairs/gputhreads;
+        if (use_gpu && tid < ngpu) {
                 //set CUDA device to this thread id
                 //should never have more threads than GPUs
                 cudaSetDevice(tid);
@@ -553,6 +557,8 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         int *gpu_cellpair_lut, *gpu_cellthread_lut;
 
         if (use_gpu) {
+            //Only execute for thread ids < ngpu
+            if (tid < ngpu) {
                 //gpu_print_cuda_error();
                 gpu_allocate_outputs_DOUBLE(&gpu_savg, &gpu_npairs, totnbins);
                 if (need_weightavg) gpu_allocate_weight_output_DOUBLE(&gpu_weightavg, totnbins);
@@ -571,6 +577,7 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
                                                                          gpu_weightavg, extra->weight_method, options->bin_type, options->los_type, autocorr,
                                                                          gpu_cellpair_lut, gpu_cellthread_lut);
                 abort_status |= status;
+            }
         } else {
 #endif //GPU
 
@@ -647,7 +654,8 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
     //Free memory and copy outputs back to CPU
     //Handle outputs and block LUTs here
     //This will sum up all multi-GPU results (use +=)
-    if (use_gpu) {
+    //Check thread id to make sure it is < ngpu
+    if (use_gpu && tid < ngpu) {
         //Copy outputs back to CPU
         for (int j = 0; j < totnbins; j++) {
             npairs[j] += (uint64_t)gpu_npairs[j];

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -420,9 +420,10 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
     DOUBLE *gpu_W1, *gpu_W2;
 
     DOUBLE *gpu_min_dx, *gpu_min_dy; //min_dz not needed for GPU kernel
+    DOUBLE *gpu_supp_sqr;
 
-    DOUBLE *gpu_savg;
-    DOUBLE *gpu_weightavg, *gpu_supp_sqr;
+    //with multi-GPU mode, declare outputs within OPENMP parallel block
+    // - gpu_npairs, gpu_savg, gpu_weightavg
 
     int *gpu_same_cell;
     int64_t *gpu_icell0, *gpu_icell1;
@@ -432,7 +433,80 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
     uint8_t nw1 = (extra->weights0).num_weights;
     uint8_t nw2 = (extra->weights1).num_weights;
 
-    int *gpu_npairs;
+    //define max threads and max blocks here
+    const int max_threads = 400000000; //400M
+    const int max_blocks = (max_threads+THREADS_PER_BLOCK-1) / THREADS_PER_BLOCK; //max num blocks
+
+    //allocate global arrays here outside of OPENMP parallel block
+    //outputs and block LUTs will be allocated inside OPENMP block
+    if (use_gpu) {
+        gpu_allocate_mocks_DOUBLE(&gpu_X1, &gpu_Y1, &gpu_Z1, ND1);
+        gpu_allocate_mocks_DOUBLE(&gpu_X2, &gpu_Y2, &gpu_Z2, ND2);
+        gpu_allocate_mins_DOUBLE(&gpu_min_dx, &gpu_min_dy, num_cell_pairs);
+        gpu_allocate_cell_luts(&gpu_same_cell, &gpu_icell0, &gpu_icell1, num_cell_pairs);
+        gpu_allocate_lattice_luts(&gpu_np0, &gpu_start_idx0, totncells);
+        gpu_allocate_lattice_luts(&gpu_np1, &gpu_start_idx1, totncells);
+        if (nw1 > 0) gpu_allocate_weights_DOUBLE(&gpu_W1, ND1, nw1);
+        if (nw2 > 0) gpu_allocate_weights_DOUBLE(&gpu_W2, ND2, nw2);
+        gpu_allocate_supp_sqr_DOUBLE(&gpu_supp_sqr, nsbin);
+
+        //copy data to GPU
+        for (int i = 0; i < nsbin; i++) gpu_supp_sqr[i] = supp_sqr[i];
+
+        //int64_t tcount = 0; //thread count
+        int64_t icell1, icell2;
+        //int64_t maxc = 0, minc = 0;
+        //int64_t this_count = 0;
+        for(int64_t icellpair=0;icellpair<num_cell_pairs;icellpair++) {
+                struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[icellpair];
+                gpu_min_dx[icellpair] = this_cell_pair->min_dx;
+                gpu_min_dy[icellpair] = this_cell_pair->min_dy;
+                gpu_same_cell[icellpair] = (int)this_cell_pair->same_cell;
+                icell1 = this_cell_pair->cellindex1;
+                icell2 = this_cell_pair->cellindex2;
+                gpu_icell0[icellpair] = icell1;
+                gpu_icell1[icellpair] = icell2;
+                //thread count is total number of inner loop iterations
+                //this_count = (&lattice1[icell1])->nelements * (&lattice2[icell2])->nelements;
+                //tcount += this_count;
+                //if (this_count > maxc) maxc= this_count;
+                //if (minc == 0 || this_count < minc) minc = this_count;
+        }
+
+        //loop over lattices and populate LUTs
+        int pcount1 = 0, pcount2 = 0;
+        int64_t i1 = 0, i2 = 0;
+        for (int64_t icell = 0; icell<totncells; icell++) {
+                gpu_np0[icell] = (&lattice1[icell])->nelements;
+                gpu_np1[icell] = (&lattice2[icell])->nelements;
+                gpu_start_idx0[icell] = pcount1;
+                gpu_start_idx1[icell] = pcount2;
+                pcount1 += (&lattice1[icell])->nelements;
+                pcount2 += (&lattice2[icell])->nelements;
+                const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                const cellarray_mocks_DOUBLE *second = &lattice2[icell];
+                //loop over elements in first, second cells
+                for (int i_first = 0; i_first < first->nelements; i_first++) {
+                       //loop over weights if nw1 > 0 and copy them
+                        for (int i_w = 0; i_w < nw1; i_w++) {
+                            gpu_W1[i1*nw1+i_w] = first->weights.weights[i_w][i_first];
+                        }
+                        gpu_X1[i1] = first->x[i_first];
+                        gpu_Y1[i1] = first->y[i_first];
+                        gpu_Z1[i1++] = first->z[i_first];
+                }
+                for (int i_second = 0; i_second < second->nelements; i_second++) {
+                        //loop over weights if nw1 > 1 and copy them
+                        for (int i_w = 0; i_w < nw2; i_w++) {
+                            gpu_W2[i2*nw2+i_w] = second->weights.weights[i_w][i_second];
+                        }
+                        gpu_X2[i2] = second->x[i_second];
+                        gpu_Y2[i2] = second->y[i_second];
+                        gpu_Z2[i2++] = second->z[i_second];
+                }
+        }
+
+    }
 #endif
 
 #if defined(_OPENMP)
@@ -448,11 +522,6 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         if(need_weightavg) {
             this_weightavg = all_weightavg[tid];
         }
-/*
-#ifdef GPU
-        setCudaDevice(tid);
-#endif
-*/
 #else
         uint64_t *this_npairs = npairs;
         DOUBLE *this_savg = savg;
@@ -464,97 +533,46 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         if(need_weightavg) tmp_weightavg = (DOUBLE *) malloc(sizeof(DOUBLE)*totnbins);
 
 #ifdef GPU
+#if defined(_OPENMP)
+        int64_t cellpair_start = tid*num_cell_pairs/numthreads;
+        int64_t cellpair_end = (tid+1)*num_cell_pairs/numthreads;
+        if (use_gpu) {
+                //set CUDA device to this thread id
+                //should never have more threads than GPUs
+                cudaSetDevice(tid);
+        }
+#else
+        int64_t cellpair_start = 0;
+        int64_t cellpair_end = num_cell_pairs;
+#endif //USE_OMP
+
+        //declare and populate output arrays and block LUTs for GPU here, within OPENMP parallel block
+        DOUBLE *gpu_savg;
+        DOUBLE *gpu_weightavg;
+        int *gpu_npairs;
+        int *gpu_cellpair_lut, *gpu_cellthread_lut;
+
         if (use_gpu) {
                 //gpu_print_cuda_error();
-                gpu_allocate_mocks_DOUBLE(&gpu_X1, &gpu_Y1, &gpu_Z1, ND1);
-                gpu_allocate_mocks_DOUBLE(&gpu_X2, &gpu_Y2, &gpu_Z2, ND2);
-                gpu_allocate_mins_DOUBLE(&gpu_min_dx, &gpu_min_dy, num_cell_pairs);
-                gpu_allocate_cell_luts(&gpu_same_cell, &gpu_icell0, &gpu_icell1, num_cell_pairs);
-                gpu_allocate_lattice_luts(&gpu_np0, &gpu_start_idx0, totncells);
-                gpu_allocate_lattice_luts(&gpu_np1, &gpu_start_idx1, totncells);
-                if (nw1 > 0) gpu_allocate_weights_DOUBLE(&gpu_W1, ND1, nw1);
-                if (nw2 > 0) gpu_allocate_weights_DOUBLE(&gpu_W2, ND2, nw2);
-
                 gpu_allocate_outputs_DOUBLE(&gpu_savg, &gpu_npairs, totnbins);
                 if (need_weightavg) gpu_allocate_weight_output_DOUBLE(&gpu_weightavg, totnbins);
-                gpu_allocate_supp_sqr_DOUBLE(&gpu_supp_sqr, nsbin);
+                gpu_allocate_block_luts(&gpu_cellpair_lut, &gpu_cellthread_lut, max_blocks);
 
-                for (int i = 0; i < nsbin; i++) gpu_supp_sqr[i] = supp_sqr[i];
-
-                //loop over cell pairs and populate GPU arrays
-                int64_t tcount = 0; //thread count
-                int64_t icell1, icell2;
-                int64_t maxc = 0, minc = 0;
-                int64_t this_count = 0;
-                for(int64_t icellpair=0;icellpair<num_cell_pairs;icellpair++) {
-                        struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[icellpair];
-                        gpu_min_dx[icellpair] = this_cell_pair->min_dx;
-                        gpu_min_dy[icellpair] = this_cell_pair->min_dy;
-                        //gpu_min_dz[icellpair] = this_cell_pair->min_dz;
-                        gpu_same_cell[icellpair] = (int)this_cell_pair->same_cell;
-                        icell1 = this_cell_pair->cellindex1;
-                        icell2 = this_cell_pair->cellindex2;
-                        gpu_icell0[icellpair] = icell1;
-                        gpu_icell1[icellpair] = icell2;
-                        //thread count is total number of inner loop iterations
-                        this_count = (&lattice1[icell1])->nelements * (&lattice2[icell2])->nelements;
-                        tcount += this_count;
-                        if (this_count > maxc) maxc= this_count;
-                        if (minc == 0 || this_count < minc) minc = this_count;
-                }
-
-                //loop over lattices and populate LUTs
-                int pcount1 = 0, pcount2 = 0;
-                int64_t i1 = 0, i2 = 0;
-                for (int64_t icell = 0; icell<totncells; icell++) {
-                        gpu_np0[icell] = (&lattice1[icell])->nelements;
-                        gpu_np1[icell] = (&lattice2[icell])->nelements;
-                        gpu_start_idx0[icell] = pcount1;
-                        gpu_start_idx1[icell] = pcount2;
-                        pcount1 += (&lattice1[icell])->nelements;
-                        pcount2 += (&lattice2[icell])->nelements;
-                        const cellarray_mocks_DOUBLE *first = &lattice1[icell];
-                        const cellarray_mocks_DOUBLE *second = &lattice2[icell];
-                        //loop over elements in first, second cells
-                        for (int i_first = 0; i_first < first->nelements; i_first++) {
-                                //loop over weights if nw1 > 0 and copy them
-                                for (int i_w = 0; i_w < nw1; i_w++) {
-                                    gpu_W1[i1*nw1+i_w] = first->weights.weights[i_w][i_first];
-                                }
-                                gpu_X1[i1] = first->x[i_first];
-                                gpu_Y1[i1] = first->y[i_first];
-                                gpu_Z1[i1++] = first->z[i_first];
-                        }
-                        for (int i_second = 0; i_second < second->nelements; i_second++) {
-                                //loop over weights if nw1 > 1 and copy them
-                                for (int i_w = 0; i_w < nw2; i_w++) {
-                                    gpu_W2[i2*nw2+i_w] = second->weights.weights[i_w][i_second];
-                                }
-                                gpu_X2[i2] = second->x[i_second];
-                                gpu_Y2[i2] = second->y[i_second];
-                                gpu_Z2[i2++] = second->z[i_second];
-                        }
-                }
-
-        }
-#endif
-
-#ifdef GPU
-        if (use_gpu) {
-                //if using GPU, call GPU version of countpairs_s_mu_mocks_gpu_DOUBLE here
+                //if using multi GPU + OPENMP, call GPU version of countpairs_s_mu_mocks_gpu_DOUBLE here
                 const int status = countpairs_s_mu_mocks_gpu_DOUBLE(ND1, gpu_X1, gpu_Y1, gpu_Z1, gpu_W1, nw1,
                                                                          ND2, gpu_X2, gpu_Y2, gpu_Z2, gpu_W2, nw2,
                                                                          gpu_same_cell,
                                                                          gpu_icell0, gpu_icell1, num_cell_pairs,
+                                                                         cellpair_start, cellpair_end,
                                                                          gpu_np0, gpu_np1, gpu_start_idx0, gpu_start_idx1,
                                                                          smax, smin, nsbin, nmu_bins, gpu_supp_sqr, mu_max,
                                                                          gpu_min_dx, gpu_min_dy,
                                                                          gpu_savg, gpu_npairs,
-                                                                         gpu_weightavg, extra->weight_method, options->bin_type, options->los_type, autocorr);
+                                                                         gpu_weightavg, extra->weight_method, options->bin_type, options->los_type, autocorr,
+                                                                         gpu_cellpair_lut, gpu_cellthread_lut);
                 abort_status |= status;
         } else {
-#endif
-
+#endif //GPU
 
 #if defined(_OPENMP)
 #pragma omp for schedule(dynamic)
@@ -625,11 +643,35 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
 
     free(tmp_savg);
     free(tmp_weightavg);
+#ifdef GPU
+    //Free memory and copy outputs back to CPU
+    //Handle outputs and block LUTs here
+    //This will sum up all multi-GPU results (use +=)
+    if (use_gpu) {
+        //Copy outputs back to CPU
+        for (int j = 0; j < totnbins; j++) {
+            npairs[j] += (uint64_t)gpu_npairs[j];
+        }
+        if(options->need_avg_sep) {
+            for (int j = 0; j < totnbins; j++) {
+                savg[j] += gpu_savg[j];
+            }
+        }
+        gpu_free_outputs_DOUBLE(gpu_savg, gpu_npairs);
+
+        if (need_weightavg) {
+            for (int j = 0; j < totnbins; j++) {
+                weightavg[j] += gpu_weightavg[j];
+            }
+            gpu_free_weight_output_DOUBLE(gpu_weightavg);
+        }
+        gpu_free_block_luts(gpu_cellpair_lut, gpu_cellthread_lut);
+    }
+#endif
+
 #if defined(_OPENMP)
     }//close the omp parallel region
 #endif//USE_OMP
-    free(all_cell_pairs);
-
 #ifdef GPU
     //Free memory and copy outputs back to CPU
     if (use_gpu) {
@@ -640,26 +682,9 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUB
         gpu_free_lattice_luts(gpu_np0, gpu_start_idx0);
         gpu_free_lattice_luts(gpu_np1, gpu_start_idx1);
         gpu_free_supp_sqr_DOUBLE(gpu_supp_sqr);
-
-        //Copy outputs back to CPU
-        for (int j = 0; j < totnbins; j++) {
-            npairs[j] = (uint64_t)gpu_npairs[j];
-        }
-        if(options->need_avg_sep) {
-            for (int j = 0; j < totnbins; j++) {
-                savg[j] = gpu_savg[j];
-            }
-        }
-        gpu_free_outputs_DOUBLE(gpu_savg, gpu_npairs);
-
-        if (need_weightavg) {
-            for (int j = 0; j < totnbins; j++) {
-                weightavg[j] = gpu_weightavg[j];
-            }
-            gpu_free_weight_output_DOUBLE(gpu_weightavg);
-        }
     }
 #endif
+    free(all_cell_pairs);
 
     if(options->copy_particles == 0) {
         int64_t *original_index = lattice1[0].original_index;

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
@@ -1597,13 +1597,15 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
                                                         const int64_t N1, DOUBLE *x1, DOUBLE *y1, DOUBLE *z1, DOUBLE *weights1, uint8_t nw1,
                                                         int *same_cell,
                                                         int64_t *gpu_icell0, int64_t *gpu_icell1, int64_t num_cell_pairs,
+                                                        int64_t cell_pair_start, int64_t cell_pair_end,
                                                         int *gpu_np0, int *gpu_np1, int *gpu_start_idx0, int *gpu_start_idx1,
                                                         const DOUBLE smax, const DOUBLE smin, const int nsbin,
                                                         const int nmu_bins, const DOUBLE *supp_sqr, const DOUBLE mu_max,
                                                         DOUBLE *min_xdiff, DOUBLE *min_ydiff,
                                                         DOUBLE *savg, int *npairs,
                                                         DOUBLE *weightavg, const weight_method_t weight_method,
-                                                        const bin_type_t bin_type, const los_type_t los_type, const int autocorr)
+                                                        const bin_type_t bin_type, const los_type_t los_type, const int autocorr,
+                                                        int *cellpair_lut, int *cellthread_lut)
 {
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
@@ -1628,22 +1630,32 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
     const int max_threads = 400000000; //400M
     const int max_blocks = (max_threads+THREADS_PER_BLOCK-1) / THREADS_PER_BLOCK; //max num blocks
 
-    int *cellpair_lut, *cellthread_lut;
-    gpu_allocate_block_luts(&cellpair_lut, &cellthread_lut, max_blocks);
+    //7/17/23 - moved allocation of cellpair_lut and cellthread_lut to countpairs_mocks_impl
 
     /*----------------- GPU CODE --------------------*/
 
     //We want to loop over gpu_icell0, gpu_icell1 (length num_cell_pairs)
     //Striding through the kernel with a reasonable number of threads
     //Where threads = sum(gpu_np0[icell0[i]] * gpu_np1[icell1[i]])
-    int i = 0; 
+
+    //With multi-GPU support, i does not start at 0 necessarily
+    //total cell pairs are divided among GPUs with each handling a fraction
+    //of overall arrays from cell_pair_start to cell_pair_end.
+    //For 1 GPU, i starts at 0 and cell_pair_end == total_cell_pairs
+
+    int64_t i = cell_pair_start;
+
+    //get CUDA device
+    int d;
+    cudaGetDevice(&d);
+
     int status = EXIT_FAILURE; 
-    while (i < num_cell_pairs) {
-        int i_start = i;
+    while (i < cell_pair_end) {
+        int64_t i_start = i;
         int tot_nblocks = 0;
         int this_cell_threads = 0;
         int nblocks = 0;
-        while (i < num_cell_pairs && nblocks < max_blocks) {
+        while (i < cell_pair_end && nblocks < max_blocks) {
             //nthreads += gpu_np0[gpu_icell0[i]] * gpu_np1[gpu_icell1[i]];
             this_cell_threads = gpu_np0[gpu_icell0[i]] * gpu_np1[gpu_icell1[i]];
             nblocks = (this_cell_threads+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK;
@@ -1658,7 +1670,7 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
             i++;
         }
         int nthreads = tot_nblocks * THREADS_PER_BLOCK;
-        //fprintf(stderr,"Cellpair %d to %d of %ld: nthreads = %d\n", i_start, i, num_cell_pairs, nthreads);
+        fprintf(stderr,"GPU %d: Cellpair %ld to %ld of %ld: nthreads = %d\n", d, i_start, i, num_cell_pairs, nthreads);
 
         status = gpu_batch_countpairs_s_mu_mocks_DOUBLE(x0, y0, z0, weights0, nw0,
                        x1, y1, z1, weights1, nw1,
@@ -1674,7 +1686,7 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
                        inv_sstep, smin_invstep,
                        need_savg, weight_method, autocorr, los_type, bin_type);
     }
-    gpu_free_block_luts(cellpair_lut, cellthread_lut);
+    //no longer need to free block LUTs here, done in countpairs_mocks_impl
 
     return status;
 }//end of GPU code

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
@@ -1605,7 +1605,7 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
                                                         DOUBLE *savg, int *npairs,
                                                         DOUBLE *weightavg, const weight_method_t weight_method,
                                                         const bin_type_t bin_type, const los_type_t los_type, const int autocorr,
-                                                        int *cellpair_lut, int *cellthread_lut)
+                                                        int *cellpair_lut, int *cellthread_lut, uint8_t verbose)
 {
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
@@ -1670,7 +1670,7 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
             i++;
         }
         int nthreads = tot_nblocks * THREADS_PER_BLOCK;
-        fprintf(stderr,"GPU %d: Cellpair %ld to %ld of %ld: nthreads = %d\n", d, i_start, i, num_cell_pairs, nthreads);
+        if (verbose) fprintf(stderr,"GPU %d: Cellpair %ld to %ld of %ld: nthreads = %d\n", d, i_start, i, num_cell_pairs, nthreads);
 
         status = gpu_batch_countpairs_s_mu_mocks_DOUBLE(x0, y0, z0, weights0, nw0,
                        x1, y1, z1, weights1, nw1,

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
@@ -1658,7 +1658,7 @@ static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0,
             i++;
         }
         int nthreads = tot_nblocks * THREADS_PER_BLOCK;
-        fprintf(stderr,"Cellpair %d to %d of %ld: nthreads = %d\n", i_start, i, num_cell_pairs, nthreads);
+        //fprintf(stderr,"Cellpair %d to %d of %ld: nthreads = %d\n", i_start, i, num_cell_pairs, nthreads);
 
         status = gpu_batch_countpairs_s_mu_mocks_DOUBLE(x0, y0, z0, weights0, nw0,
                        x1, y1, z1, weights1, nw1,

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
@@ -20,6 +20,10 @@
 
 #include "weight_functions_DOUBLE.h"
 
+#ifdef GPU
+#include "countpairs_s_mu_mocks_gpu.h"
+#endif
+
 #if defined(__AVX512F__)
 #include "avx512_calls.h"
 
@@ -1586,3 +1590,92 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
 
     return EXIT_SUCCESS;
 }//end of fallback code
+
+#ifdef GPU
+
+static inline int countpairs_s_mu_mocks_gpu_DOUBLE(const int64_t N0, DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, DOUBLE *weights0, uint8_t nw0,
+                                                        const int64_t N1, DOUBLE *x1, DOUBLE *y1, DOUBLE *z1, DOUBLE *weights1, uint8_t nw1,
+                                                        int *same_cell,
+                                                        int64_t *gpu_icell0, int64_t *gpu_icell1, int64_t num_cell_pairs,
+                                                        int *gpu_np0, int *gpu_np1, int *gpu_start_idx0, int *gpu_start_idx1,
+                                                        const DOUBLE smax, const DOUBLE smin, const int nsbin,
+                                                        const int nmu_bins, const DOUBLE *supp_sqr, const DOUBLE mu_max,
+                                                        DOUBLE *min_xdiff, DOUBLE *min_ydiff,
+                                                        DOUBLE *savg, int *npairs,
+                                                        DOUBLE *weightavg, const weight_method_t weight_method,
+                                                        const bin_type_t bin_type, const los_type_t los_type, const int autocorr)
+{
+    if(N0 == 0 || N1 == 0) {
+        return EXIT_SUCCESS;
+    }
+
+    if(npairs == NULL) {
+        return EXIT_FAILURE;
+    }
+
+    const int32_t need_savg = savg != NULL;
+    //calculate sqr_smin and sqr_smax once here
+    const DOUBLE sqr_smin=smin*smin, sqr_smax=smax*smax;
+    DOUBLE inv_sstep=0., smin_invstep=0.;
+    if (bin_type == BIN_LIN) {
+        inv_sstep = (nsbin - 1)/(smax - smin);
+        smin_invstep = 1 - smin*inv_sstep; //trick to avoid adding one to (r - rmin)/rstep
+    }
+
+    const DOUBLE sqr_mumax = mu_max*mu_max;
+    const DOUBLE inv_dmu = ((DOUBLE) nmu_bins)/(2*mu_max);
+    const DOUBLE mumin_invstep = mu_max*inv_dmu;
+    const int max_threads = 400000000; //400M
+    const int max_blocks = (max_threads+THREADS_PER_BLOCK-1) / THREADS_PER_BLOCK; //max num blocks
+
+    int *cellpair_lut, *cellthread_lut;
+    gpu_allocate_block_luts(&cellpair_lut, &cellthread_lut, max_blocks);
+
+    /*----------------- GPU CODE --------------------*/
+
+    //We want to loop over gpu_icell0, gpu_icell1 (length num_cell_pairs)
+    //Striding through the kernel with a reasonable number of threads
+    //Where threads = sum(gpu_np0[icell0[i]] * gpu_np1[icell1[i]])
+    int i = 0; 
+    int status = EXIT_FAILURE; 
+    while (i < num_cell_pairs) {
+        int i_start = i;
+        int tot_nblocks = 0;
+        int this_cell_threads = 0;
+        int nblocks = 0;
+        while (i < num_cell_pairs && nblocks < max_blocks) {
+            //nthreads += gpu_np0[gpu_icell0[i]] * gpu_np1[gpu_icell1[i]];
+            this_cell_threads = gpu_np0[gpu_icell0[i]] * gpu_np1[gpu_icell1[i]];
+            nblocks = (this_cell_threads+THREADS_PER_BLOCK-1)/THREADS_PER_BLOCK;
+            if (nblocks + tot_nblocks > max_blocks) break;
+            int tnum = 0;
+            for (int j = tot_nblocks; j < tot_nblocks+nblocks; j++) {
+                cellpair_lut[j] = i;
+                cellthread_lut[j] = tnum;
+                tnum += 512;
+            }
+            tot_nblocks += nblocks;
+            i++;
+        }
+        int nthreads = tot_nblocks * THREADS_PER_BLOCK;
+        fprintf(stderr,"Cellpair %d to %d of %ld: nthreads = %d\n", i_start, i, num_cell_pairs, nthreads);
+
+        status = gpu_batch_countpairs_s_mu_mocks_DOUBLE(x0, y0, z0, weights0, nw0,
+                       x1, y1, z1, weights1, nw1,
+                       nthreads, gpu_np0, gpu_np1,
+                       same_cell, gpu_icell0, gpu_icell1,
+                       cellpair_lut, cellthread_lut,
+                       gpu_start_idx0, gpu_start_idx1,
+                       min_xdiff, min_ydiff,
+                       savg, npairs, weightavg, supp_sqr,
+                       sqr_smax, sqr_smin, nsbin,
+                       nmu_bins,
+                       sqr_mumax, inv_dmu, mumin_invstep,
+                       inv_sstep, smin_invstep,
+                       need_savg, weight_method, autocorr, los_type, bin_type);
+    }
+    gpu_free_block_luts(cellpair_lut, cellthread_lut);
+
+    return status;
+}//end of GPU code
+#endif

--- a/mocks/python_bindings/_countpairs_mocks.c
+++ b/mocks/python_bindings/_countpairs_mocks.c
@@ -2156,6 +2156,7 @@ static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args
     struct config_options options = get_config_options();
     options.verbose = 0;
     options.instruction_set = -1;
+    options.instruction_set = 0;
     options.periodic = 0;
     options.fast_divide_and_NR_steps=0;
     options.enable_min_sep_opt = 1;
@@ -2197,6 +2198,7 @@ static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args
         "enable_min_sep_opt",
         "c_api_timer",
         "isa",/* instruction set to use of type enum isa; valid values are AVX512F, AVX, SSE, FALLBACK (enum) */
+        "gpu",
         "weight_type",
         "pair_weights",
         "sep_pair_weights",
@@ -2207,7 +2209,7 @@ static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args
         NULL
     };
 
-    if ( ! PyArg_ParseTupleAndKeywords(args, kwargs, "iiO!diO!O!O!|OO!O!O!ObbbbbbhbbbisO!O!OOII", kwlist,
+    if ( ! PyArg_ParseTupleAndKeywords(args, kwargs, "iiO!diO!O!O!|OO!O!O!ObbbbbbhbbbiisO!O!OOII", kwlist,
                                        &autocorr,&nthreads,
                                        &PyArray_Type,&bins_obj,
                                        &mu_max,&nmu_bins,
@@ -2228,6 +2230,7 @@ static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args
                                        &(options.enable_min_sep_opt),
                                        &(options.c_api_timer),
                                        &(options.instruction_set),
+                                       &(options.use_gpu),
                                        &weighting_method_str,
                                        &PyArray_Type,&pair_weight_obj,
                                        &PyArray_Type,&sep_pair_weight_obj,

--- a/rules.mk
+++ b/rules.mk
@@ -66,6 +66,9 @@ $(LIBNAME)_impl_float.o: $(UTILS_DIR)/weight_functions_float.h
 %.o: %.c $(ROOT_DIR)/common.mk $(ROOT_DIR)/utils/defs.h Makefile
 	$(CC) $(CFLAGS) $(INCLUDE) $(EXTRA_INCL) -c $< -o $@
 
+%.o: %.cu $(ROOT_DIR)/common.mk $(ROOT_DIR)/utils/defs.h Makefile
+	nvcc $(CUFLAGS) $< -o $@
+
 $(LIBRARY): $(LIBOBJS) $(ROOT_DIR)/mocks.options $(ROOT_DIR)/theory.options $(ROOT_DIR)/common.mk Makefile
 	ar rcs $@ $(LIBOBJS)
 

--- a/rules.mk
+++ b/rules.mk
@@ -96,8 +96,6 @@ ifdef PROJECT
 
 endif
 
-
-
 .PHONY: clean clena celan install lib tests distclean all realclean libs
 
 celna: clean


### PR DESCRIPTION
options struct in defs.h has additional use_gpu uint8_t Command line -gpu arg added to DDsmu_mocks executable

Four kernels developed - double and float, no waiting and pair product weighting - are in countpairs_s_mu_mocks_gpu.cu.

Makefile and common.mk and rules.mk updated to conditionally compile CUDA.  GPU code is all with ifdef GPU preprocessor directives.  Makefile should detect if nvcc is available and build with CUDA if so and without CUDA otherwise.

If built without -DGPU, and -gpu command line is specified, it will use the CPU kernel it would normally use (AVX, etc).  If built with -DGPU and -gpu command line is not specified (or passed from options struct via python interface) then again it will use the CPU kernel that would normally be selected.  Only if both -DGPU and -gpu command line option will it use GPU.

*Remaining items:
	- selection struct not implemented yet
	- OPENMP not supported yet for GPU mode but should be able to be added
	- inverse bitwise weighting not yet implemented

*Issues to be aware of
	- with no weighting, output txt file is usually bitwise identical and is always np.allclose
	- with weighting a few bins differ by double precision rounding errors but are within np.allclose
	- in float mode savg and weightavg are within np.allclose
	- in float mode, floating point rounding errors can cause slight difference in npairs, e.g. one bin may have +1 npairs in GPU mode vs CPU mode and the next door bin would have -1 npairs because of floating point rounding errors in the calculations determining which bin index the pair belongs to.

*Speed tests:
	- A100 yields ~24x speed-up for no weighting, 28x for pair product weighting over AVX for 1M particles
	- A100 yields ~70x speed-up for no weighting, 80x for pair product weighting over AVX for 8M particles
	- RTX3080 yields ~11x speed-up for both modes for 1M particles over AVX on AMD Ryzen 9
	- GeForce 1660 yields 4x speed-up for both modes for 1M particles over AVX (9x over fallback) on AMD Ryzen 9

*Notes:
	- Development of the GPU kernels required that multiple cell pairs be processed at once for maximum efficiency.
	- 400M is chosen as the maximum number of threads for each kernel call.  This value seems to work well on both A100 and consumer grad chips.
	- Unified memory is allocated and data is copied over once, then kernel is launched multiple times to loop over all cell pairs, then results are copied back to CPU memory and GPU mem freed.
	- synchronize must be done after every kernel call because of the atomicAdds to npairs, savg, weightavg
	- Arrays of primitives are used instead of the structs used in the C code.